### PR TITLE
Skip config validation as this plugin is often released after detekt core

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredService.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredService.kt
@@ -52,6 +52,9 @@ class ConfiguredService(private val project: Project) {
             maxIssuePolicy = RulesSpec.MaxIssuePolicy.AllowAny
         }
         config {
+            // Do not throw an error during annotation mode as it is a common scenario
+            // that the IntelliJ plugin is behind detekt core version-wise (new unknown config properties).
+            shouldValidateBeforeAnalysis = false
             useDefaultConfig = storage.buildUponDefaultConfig
             configPaths = configPaths()
         }


### PR DESCRIPTION
Closes - #102