### PR TITLE
Update to Detekt 1.15.0 Gradle 6.8 IntelliJ 2020.3 Java 11

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -13,11 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [8, 11]
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     env:
-      JDK_VERSION:  ${{ matrix.jdk }}
+      JDK_VERSION: 11
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
@@ -25,7 +24,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
-        java-version: ${{ matrix.jdk }}
+        java-version: 11
 
     - name: Build detekt idea plugin
       run: ./gradlew build --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,9 +18,9 @@ repositories {
 }
 
 plugins {
-    id("org.jetbrains.intellij").version("0.4.21")
+    id("org.jetbrains.intellij").version("0.6.5")
     id("com.github.ben-manes.versions") version "0.33.0"
-    kotlin("jvm").version("1.4.21")
+    kotlin("jvm").version("1.4.10")
     id("org.sonarqube") version "3.0"
     id("com.github.breadmoirai.github-release") version "2.2.12"
     id("com.jfrog.bintray") version "1.8.5"
@@ -52,11 +52,17 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+        showExceptions = true
+        showCauses = true
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
 }
 
 configure<IntelliJPluginExtension> {
     pluginName = "Detekt IntelliJ Plugin"
-    version = "2019.3"
+    version = "2020.3"
     updateSinceUntilBuild = false
     setPlugins("IntelliLang", "Kotlin")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 plugins {
     id("org.jetbrains.intellij").version("0.4.21")
     id("com.github.ben-manes.versions") version "0.33.0"
-    kotlin("jvm").version("1.4.10")
+    kotlin("jvm").version("1.4.21")
     id("org.sonarqube") version "3.0"
     id("com.github.breadmoirai.github-release") version "2.2.12"
     id("com.jfrog.bintray") version "1.8.5"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### 1.15.0
 - Update to detekt 1.15.0
 - Update to Gradle 6.8
+- Update to IntelliJ 2020.3
 - Align the major and minor version with detekt to follow semantic versions
 
 #### 1.6.1

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 #### 1.15.0
 - Update to detekt 1.15.0
+- Update to Gradle 6.8
 - Align the major and minor version with detekt to follow semantic versions
 
 #### 1.6.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### 1.15.0
+- Update to detekt 1.15.0
+- Align the major and minor version with detekt to follow semantic versions
+
 #### 1.6.1
 
 - Update to detekt 1.14.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-detektIntellijPluginVersion=1.6.1
-detektVersion=1.14.2
+detektIntellijPluginVersion=1.15.0
+detektVersion=1.15.0
 kotlinVersion=1.4.10
 junitVersion=5.7.0
 assertjVersion=3.17.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
 
     <change-notes><![CDATA[
       <ul>
+        <li>1.15.0 - Based on detekt 1.15.0.</li>
         <li>1.6.1 - Based on detekt 1.14.2.</li>
         <li>1.6.0 - Based on detekt 1.14.1.</li>
         <li>1.5.0 - Based on detekt 1.11.0.</li>

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
@@ -58,7 +58,7 @@ class ConfiguredServiceTest : DetektPluginTestCase() {
     fun `expect detekt runs successfully`() {
         val service = ConfiguredService(project)
 
-        // If a ClassCastException is thrown, it means detekt-core was called and creating a KotlinEnvironment
+        // If a NoSuchMethodError is thrown, it means detekt-core was called and creating a KotlinEnvironment
         // failed due to conflicted compiler vs embedded-compiler dependency.
         // IntelliJ isolates plugins in an own classloader so detekt runs fine.
         // In the testcase this is not possible but it is enough to prove detekt runs and does not crash due to
@@ -69,7 +69,12 @@ class ConfiguredServiceTest : DetektPluginTestCase() {
                 resourceAsPath("testData/Poko.kt").toString(),
                 autoCorrect = false
             )
-        }.isInstanceOf(ClassCastException::class.java)
+        }.isInstanceOf(NoSuchMethodError::class.java)
+            .hasMessage("'org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment " +
+                "org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment\$Companion.createForProduction(" +
+                "org.jetbrains.kotlin.com.intellij.openapi.Disposable, " +
+                "org.jetbrains.kotlin.config.CompilerConfiguration, " +
+                "org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles)'")
     }
 
     @Test


### PR DESCRIPTION
Following semantic versions and aligning the intellij plugin version with detekt version could reduce confusion and manual version check if necessary.