### PR TITLE
add identifiable annotation prefix

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
@@ -38,7 +38,12 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
         val configuration = DetektConfigStorage.instance(file.project)
         for (finding in annotationResult) {
             val textRange = finding.charPosition.toTextRange()
-            val message = finding.id + ": " + finding.messageOrDescription()
+            val message = buildString {
+                append("Detekt - ")
+                append(finding.id)
+                append(": ")
+                append(finding.messageOrDescription())
+            }
             val severity = if (configuration.treatAsError) HighlightSeverity.ERROR else HighlightSeverity.WARNING
             holder.newAnnotation(severity, message)
                 .range(textRange)


### PR DESCRIPTION
Currently, the annotation made by detekt is not identifiable whether detekt creates the annotation or not.
This PR makes the annotation which is annotated by detekt identifiable.
<img width="934" alt="貼り付けた画像_2021_08_02_21_03" src="https://user-images.githubusercontent.com/3395369/127858998-ecab3a6d-24f5-48dd-ab46-98b5a3e5f5a1.png">
