### PR TITLE
Implement error reporting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 plugins {
-    id("org.jetbrains.intellij").version("1.5.3")
+    id("org.jetbrains.intellij").version("1.6.0")
     id("com.github.ben-manes.versions").version("0.42.0")
     kotlin("jvm").version("1.6.20")
     id("com.github.breadmoirai.github-release").version("2.2.12")

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/GitHubErrorReporting.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/GitHubErrorReporting.kt
@@ -1,0 +1,88 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.DataManager
+import com.intellij.ide.scratch.ScratchRootType
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.fileTypes.PlainTextLanguage
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.Consumer
+import org.apache.http.client.utils.URIBuilder
+import java.awt.Component
+
+class GitHubErrorReporting : ErrorReportSubmitter() {
+
+    override fun getReportActionText(): String = "Open GitHub Issue"
+
+    override fun submit(
+        events: Array<out IdeaLoggingEvent>,
+        additionalInfo: String?,
+        parentComponent: Component,
+        consumer: Consumer<in SubmittedReportInfo>
+    ): Boolean {
+        val uri = URIBuilder("https://github.com/detekt/detekt-intellij-plugin/issues/new")
+            .addParameter("title", events.mapNotNull { it.throwableText.firstLine() }.joinToString("; "))
+            .addParameter("labels", "bug")
+            .addParameter("body", formatIssueBody(additionalInfo))
+            .build()
+
+        runCatching {
+            BrowserUtil.browse(uri)
+            ApplicationManager.getApplication()
+                .invokeLater { openStacktraceScratchFile(parentComponent, formatStacktrace(events)) }
+        }.onFailure {
+            consumer.consume(SubmittedReportInfo(SubmittedReportInfo.SubmissionStatus.FAILED))
+            return false
+        }.onSuccess {
+            consumer.consume(SubmittedReportInfo(SubmittedReportInfo.SubmissionStatus.NEW_ISSUE))
+        }
+        return true
+    }
+
+    private fun openStacktraceScratchFile(parentComponent: Component, stacktrace: String) {
+        val dataContext = DataManager.getInstance().getDataContext(parentComponent)
+        val project = CommonDataKeys.PROJECT.getData(dataContext)
+        requireNotNull(project)
+        val scratchFile = ScratchRootType.getInstance()
+            .createScratchFile(project, "detekt-idea-stacktrace.md", PlainTextLanguage.INSTANCE, stacktrace)
+        requireNotNull(scratchFile)
+        OpenFileDescriptor(project, scratchFile).navigate(true)
+    }
+
+    private fun formatStacktrace(events: Array<out IdeaLoggingEvent>): String =
+        "Please copy following stacktrace to the opened issue body." +
+                System.lineSeparator() +
+                System.lineSeparator() +
+                events.joinToString(System.lineSeparator()) {
+                    """
+```
+${it.throwableText.trim()}
+```
+            """.trimIndent()
+                }
+
+    private fun formatIssueBody(additionalInfo: String?): String = """
+        ## Bug description
+        ${additionalInfo ?: "Please include steps to reproduce expected and actual behavior."}
+    
+        ## Environment
+        - detekt Idea Version: ${PluginUtils.pluginVersion()}
+        - Platform Version: ${PluginUtils.platformVersion()}
+        - Platform Vendor: ${SystemInfo.JAVA_VENDOR}
+        - Java Version: ${SystemInfo.JAVA_VERSION}
+        - OS Name: ${SystemInfo.OS_NAME}
+    
+        ## Stacktrace
+        
+        ```
+        Please include the stacktrace from the temporary scratch issue.
+        ```
+    """.trimIndent()
+
+    private fun String.firstLine(): String? = trim().split(System.lineSeparator()).firstOrNull()
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginUtils.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginUtils.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.extensions.PluginId
+import io.gitlab.arturbosch.detekt.idea.DETEKT
+
+object PluginUtils {
+
+    fun platformVersion(): String = ApplicationInfo.getInstance().fullVersion
+
+    fun pluginVersion(): String {
+        val pluginId = PluginId.getId(DETEKT)
+        val plugin = requireNotNull(PluginManagerCore.getPlugin(pluginId)) {
+            "Could not find detekt plugin descriptor."
+        }
+        return plugin.version
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,9 +12,10 @@
 
     <depends>com.intellij.modules.lang</depends>
 
-    <idea-version since-build="201"/>
+    <idea-version since-build="203"/>
 
     <extensions defaultExtensionNs="com.intellij">
+        <errorHandler implementation="io.gitlab.arturbosch.detekt.idea.util.GitHubErrorReporting"/>
         <externalAnnotator language="kotlin"
                            implementationClass="io.gitlab.arturbosch.detekt.idea.DetektAnnotator"/>
 


### PR DESCRIPTION
We now allow the user to report any plugin errors by opening a github issue pre-filled with environment informationen
and prompt him to copy the stacktraces from a scratch file to the issue body.

Unfortunately the stacktrace is too long to include it in the url.

The bug description is the entered text by the user from the IntelliJ Report screen or a default text like the one in the screenshot.

![2022-05-26T01:26:56,319133931+02:00](https://user-images.githubusercontent.com/20924106/170387383-2e5d46c5-29d5-4f6a-a0f6-dbeeadd1919d.png)
![2022-05-26T01:32:39,243522913+02:00](https://user-images.githubusercontent.com/20924106/170387386-1d6e3c25-f04f-4093-85ef-4042be1d3702.png)
