### PR TITLE
Include slf4j-nop as runtimeOnly dependency for KtLint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.detekt.api)
     implementation(libs.detekt.tooling)
 
+    runtimeOnly(libs.slf4j.nop)
     runtimeOnly(libs.detekt.core)
     runtimeOnly(libs.detekt.rules)
     runtimeOnly(libs.detekt.formatting)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,3 +10,4 @@ detekt-tooling = { group = "io.gitlab.arturbosch.detekt", name = "detekt-tooling
 detekt-testUtils = { group = "io.gitlab.arturbosch.detekt", name = "detekt-test-utils", version.ref = "detekt" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version = "3.22.0" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.8.2" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version = "1.7.36"  }


### PR DESCRIPTION
Fixes #163
Fixes #161
Fixes #160

We start getting 2 star ratings in the marketplace. Should we release a hotfix with this independent of detekt-core including these dependencies ? - https://plugins.jetbrains.com/plugin/10761-detekt/reviews#review=68022