### PR TITLE
Run detekt annotator only on kotlin files

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
@@ -11,6 +11,7 @@ import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.idea.config.DetektConfigStorage
 import io.gitlab.arturbosch.detekt.idea.intention.AutoCorrectIntention
 import io.gitlab.arturbosch.detekt.idea.util.isDetektEnabled
+import io.gitlab.arturbosch.detekt.idea.util.isKotlinFile
 import io.gitlab.arturbosch.detekt.idea.util.showNotification
 
 class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
@@ -21,6 +22,10 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
         if (!collectedInfo.project.isDetektEnabled()) {
             return emptyList()
         }
+        if (collectedInfo.isKotlinFile()) {
+            return emptyList()
+        }
+
         val service = ConfiguredService(collectedInfo.project)
 
         val problems = service.validate()

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProjectUtils.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProjectUtils.kt
@@ -7,15 +7,19 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.newEditor.SettingsDialog
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
 import io.gitlab.arturbosch.detekt.idea.DETEKT
 import io.gitlab.arturbosch.detekt.idea.config.DetektConfig
 import io.gitlab.arturbosch.detekt.idea.config.DetektConfigStorage
+import org.jetbrains.kotlin.idea.KotlinLanguage
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 
 fun Project.isDetektEnabled(): Boolean =
     DetektConfigStorage.instance(this).enableDetekt
+
+fun PsiFile.isKotlinFile(): Boolean = language == KotlinLanguage.INSTANCE
 
 fun absolutePath(project: Project, path: String): String =
     if (path.isBlank() || File(path).isAbsolute) {


### PR DESCRIPTION
- Read psi text only in read actions
- Format only in write actions

Fixes #159 