### PR TITLE
Report file level findings as a file level annotation instead of marking the whole file

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektAnnotator.kt
@@ -55,6 +55,10 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
             val annotationBuilder = holder.newAnnotation(severity, message)
                 .range(textRange)
 
+            if (textRange == file.textRange) {
+                annotationBuilder.fileLevel()
+            }
+
             if (finding is CorrectableCodeSmell) {
                 annotationBuilder.withFix(AutoCorrectIntention())
             }


### PR DESCRIPTION
Fixes #173

![2022-06-03T20:49:07,407094174+02:00](https://user-images.githubusercontent.com/20924106/171930109-206a56b5-fc9e-4962-a9c0-9ee5a9a4e49d.png)
