### PR TITLE
Enable plugin by default and use the default config

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/DetektConfigStorage.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/DetektConfigStorage.kt
@@ -14,13 +14,13 @@ import com.intellij.util.xmlb.annotations.Tag
 class DetektConfigStorage : PersistentStateComponent<DetektConfigStorage> {
 
     @Tag
-    var enableDetekt: Boolean = false
+    var enableDetekt: Boolean = true
 
     @Tag
     var enableFormatting: Boolean = false
 
     @Tag
-    var buildUponDefaultConfig: Boolean = false
+    var buildUponDefaultConfig: Boolean = true
 
     @Tag
     var enableAllRules: Boolean = false


### PR DESCRIPTION
Fixes #115

It's kinda cumbersome to enable the plugin on each new IntelliJ install.