### PR TITLE
Generate the whole bug report as scratch file and prompt to copy paste it

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/GitHubErrorReporting.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/GitHubErrorReporting.kt
@@ -4,7 +4,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.ide.DataManager
 import com.intellij.ide.scratch.ScratchRootType
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
@@ -23,18 +23,44 @@ class GitHubErrorReporting : ErrorReportSubmitter() {
         events: Array<out IdeaLoggingEvent>,
         additionalInfo: String?,
         parentComponent: Component,
-        consumer: Consumer<in SubmittedReportInfo>
+        consumer: Consumer<in SubmittedReportInfo>,
     ): Boolean {
         val uri = URIBuilder("https://github.com/detekt/detekt-intellij-plugin/issues/new")
             .addParameter("title", events.mapNotNull { it.throwableText.firstLine() }.joinToString("; "))
             .addParameter("labels", "bug")
-            .addParameter("body", formatIssueBody(additionalInfo))
+            .addParameter("body", "Please copy paste the generated bug report.")
             .build()
+
+        val bugReport = buildString {
+            appendLine("## Bug description")
+            appendLine()
+            appendLine(additionalInfo ?: "Please include steps to reproduce expected and actual behavior.")
+            appendLine()
+            appendLine("## Environment")
+            appendLine()
+            appendLine("- detekt Idea Version: ${PluginUtils.pluginVersion()}")
+            appendLine("- Platform Version: ${PluginUtils.platformVersion()}")
+            appendLine("- Platform Vendor: ${SystemInfo.JAVA_VENDOR}")
+            appendLine("- Java Version: ${SystemInfo.JAVA_VERSION}")
+            appendLine("- OS Name: ${SystemInfo.OS_NAME}")
+            appendLine()
+            appendLine("## Stacktrace")
+            appendLine()
+            appendLine(
+                events.map { it.throwableText.trim() }
+                    .joinToString(System.lineSeparator()) {
+                        """
+                        |```
+                        |$it
+                        |```
+                        """.trimMargin()
+                    }
+            )
+        }
 
         return runCatching {
             BrowserUtil.browse(uri)
-            ApplicationManager.getApplication()
-                .invokeLater { openStacktraceScratchFile(parentComponent, formatStacktrace(events)) }
+            invokeLater { openStacktraceScratchFile(parentComponent, bugReport) }
             consumer.consume(SubmittedReportInfo(SubmittedReportInfo.SubmissionStatus.NEW_ISSUE))
             true
         }.getOrElse {
@@ -43,45 +69,19 @@ class GitHubErrorReporting : ErrorReportSubmitter() {
         }
     }
 
-    private fun openStacktraceScratchFile(parentComponent: Component, stacktrace: String) {
+    private fun openStacktraceScratchFile(parentComponent: Component, bugReportText: String) {
         val dataContext = DataManager.getInstance().getDataContext(parentComponent)
         val project = CommonDataKeys.PROJECT.getData(dataContext)
         requireNotNull(project)
-        val scratchFile = ScratchRootType.getInstance()
-            .createScratchFile(project, "detekt-idea-stacktrace.md", PlainTextLanguage.INSTANCE, stacktrace)
+        val scratchFile = ScratchRootType.getInstance().createScratchFile(
+            project,
+            "detekt-idea-stacktrace.md",
+            PlainTextLanguage.INSTANCE,
+            bugReportText
+        )
         requireNotNull(scratchFile)
         OpenFileDescriptor(project, scratchFile).navigate(true)
     }
-
-    private fun formatStacktrace(events: Array<out IdeaLoggingEvent>): String =
-        "Please copy following stacktrace to the opened issue body." +
-                System.lineSeparator() +
-                System.lineSeparator() +
-                events.joinToString(System.lineSeparator()) {
-                    """
-```
-${it.throwableText.trim()}
-```
-            """.trimIndent()
-                }
-
-    private fun formatIssueBody(additionalInfo: String?): String = """
-        ## Bug description
-        ${additionalInfo ?: "Please include steps to reproduce expected and actual behavior."}
-    
-        ## Environment
-        - detekt Idea Version: ${PluginUtils.pluginVersion()}
-        - Platform Version: ${PluginUtils.platformVersion()}
-        - Platform Vendor: ${SystemInfo.JAVA_VENDOR}
-        - Java Version: ${SystemInfo.JAVA_VERSION}
-        - OS Name: ${SystemInfo.OS_NAME}
-    
-        ## Stacktrace
-        
-        ```
-        Please include the stacktrace from the temporary scratch issue.
-        ```
-    """.trimIndent()
 
     private fun String.firstLine(): String? = trim().split(System.lineSeparator()).firstOrNull()
 }


### PR DESCRIPTION
We are getting many bug reports like https://github.com/detekt/detekt-intellij-plugin/issues/199
where the bug description and the stacktraces are missing.

Due to a maximum length of a url we can't include the stacktraces by default and copying the stacktraces seems not obvious.
So I now switched to generating the whole report in a scratch file and the user has to copy paste the whole file (github issue link is opened).

![Screenshot from 2022-07-06 12-10-23](https://user-images.githubusercontent.com/20924106/177527083-a74285e3-676e-40ec-8de5-f10a3704aead.png)
![Screenshot from 2022-07-06 12-10-00](https://user-images.githubusercontent.com/20924106/177527087-aac0ca0e-b1d0-4d2f-9c25-0df292fa76cc.png)

Closes #199