### PR TITLE
Add support for IJ 241, drop 221

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,13 +62,13 @@ tasks.publishPlugin {
 
 intellij {
     pluginName.set("Detekt IntelliJ Plugin")
-    version.set("2022.1.4")
+    version.set("2022.2.5")
     updateSinceUntilBuild.set(false)
-    plugins.set(listOf("IntelliLang", "Kotlin"))
+    plugins.set(listOf("org.intellij.intelliLang", "Kotlin"))
 }
 
 tasks.runPluginVerifier {
-    ideVersions.set(listOf("2022.1.4", "2022.2.4", "2022.3.2", "2023.1"))
+    ideVersions.set(listOf("2022.2.5", "2022.3.3", "2023.1.5", "2023.2.5", "2023.3.3", "241-EAP-SNAPSHOT"))
     failureLevel.set(listOf(DEPRECATED_API_USAGES, INVALID_PLUGIN))
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ### Changelog
 
+#### 2.4.0
+
+- Add support for IntelliJ 2024.1
+- Drop support for IntelliJ 2022.1
+
 #### 2.3.0
 
 - Based on detekt 1.23.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,5 +22,5 @@ slf4j-Api = { module = "org.slf4j:slf4j-api",  version.ref = "slfApi"}
 [plugins]
 kotlin-jvm = "org.jetbrains.kotlin.jvm:1.9.22"
 versions = "com.github.ben-manes.versions:0.50.0"
-intellij = "org.jetbrains.intellij:1.16.1"
+intellij = "org.jetbrains.intellij:1.17.0"
 github-release = "com.github.breadmoirai.github-release:2.4.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/action/AutoCorrectAction.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/action/AutoCorrectAction.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.idea.action
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -68,4 +69,6 @@ class AutoCorrectAction : AnAction(PluginUtils.pluginIcon()) {
             }
         }
     }
+
+    override fun getActionUpdateThread() = ActionUpdateThread.EDT
 }

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/webviews/RulesBrowserService.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/webviews/RulesBrowserService.kt
@@ -9,11 +9,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.util.applyIf
-import com.intellij.util.ui.StartupUiUtil
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 import javax.swing.JComponent
+import javax.swing.UIManager
 
 @Service
 class RulesBrowserService : Disposable {
@@ -57,7 +57,7 @@ class RulesBrowserService : Disposable {
     }
 
     private fun updateStyles() {
-        val ideTheme = if (StartupUiUtil.isUnderDarcula()) "dark" else "light"
+        val ideTheme = if (isDarkTheme) "dark" else "light"
         browser.cefBrowser.executeJavaScript(
             """
                 if (localStorage.theme !== "$ideTheme") {
@@ -72,6 +72,15 @@ class RulesBrowserService : Disposable {
             0,
         )
     }
+
+    // Copied from StartupUiUtil - we can't use it directly because it's @Internal
+    private val isDarkTheme: Boolean
+        get() {
+            // Do not use UIManager.getLookAndFeel().defaults because it won't work.
+            // We use UIManager.getLookAndFeelDefaults() in installTheme in com.intellij.ide.ui.laf.LafManagerImpl.doSetLaF
+            val lookAndFeelDefaults = UIManager.getLookAndFeelDefaults()
+            return lookAndFeelDefaults == null || lookAndFeelDefaults.getBoolean("ui.theme.is.dark")
+        }
 
     override fun dispose() {
         browser.dispose()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
 
     <depends>com.intellij.modules.platform</depends>
 
-    <idea-version since-build="221.6008.13"/>
+    <idea-version since-build="222.3345.118"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Turn off error reporting for now due to https://github.com/detekt/detekt-intellij-plugin/issues/271 -->

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.idea
 
 import com.intellij.openapi.components.service
-import com.intellij.util.io.readText
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.io.path.readText
 
 class ConfiguredServiceTest : MockProjectTestCase() {
 

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/KotlinParsingTestCase.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/KotlinParsingTestCase.kt
@@ -9,12 +9,12 @@ import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
-import com.intellij.util.io.readText
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import java.nio.file.Path
+import kotlin.io.path.readText
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class KotlinParsingTestCase : MockProjectTestCase() {


### PR DESCRIPTION
As per title, this PR adds support for IJ 241, which is currently throwing an error due to an action missing the update thread override. Concurrently, we had to drop support for 221 as that API isn't available until 222. We also removed one deprecated-as-error API usage by copy-pasting that function into the plugin (yeah... I know), and replaced a deprecated IJ Platform function usage with its Kotlin stdlib equivalent.

Include updating Gradle to 8.5 and Gradle IJ plugin to 1.17.0; the verifier now runs on all latest supported versions of the IJ Platform. Smoke tested on 222 and 241 EAP 3.

I took the liberty of creating a changelog entry for 2.4.0