### PR TITLE
Fix typo in notification

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProjectUtils.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProjectUtils.kt
@@ -51,7 +51,7 @@ fun List<VirtualFile>.toPathsList(): List<String> =
 fun showNotification(problems: List<String>, project: Project) {
     showNotification(
         title = DetektBundle.message("detekt.notifications.message.problemsFound"),
-        content = problems.joinToString(System.lineSeparator()) +
+        content = problems.joinToString(System.lineSeparator()) + System.lineSeparator() +
             DetektBundle.message("detekt.notifications.content.skippingRun"),
         project = project
     )


### PR DESCRIPTION
This adds a newline after the list of problems causing the run to be skipped. Otherwise there would be no space between the two.