### PR TITLE
Move project Gradle setup to IJPL Plugin 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ hs_err_pid*
 
 # Cache of project
 .gradletasknamecache
+
+# Ignore Kotlin compiler sessions
+/.kotlin/sessions
+
+# Ignore IJPL Gradle plugin cache
+/.intellijPlatform

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx2048m
 # kotlin properties
 kotlin.code.style=official
 kotlin.build.useFir=true
-kotlin.stdlib.default.dependency = false
+kotlin.stdlib.default.dependency=false
 
 # Intellij Gradle Plugin Build Features
 org.jetbrains.intellij.buildFeature.selfUpdateCheck=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,10 @@
 detekt = "1.23.8"
 # Use -beta[.number] for pre-releases
 detektIJ = "2.4.3"
-assertj = "3.27.3"
-junit5 = "5.12.0"
-junit5Platform = "1.12.0"
+assertj = "3.27.6"
+junit5 = "5.14.2"
+junit5Platform = "1.14.2"
+junit4 = "4.13.2"
 slfApi = "2.0.17"
 
 [libraries]
@@ -17,10 +18,11 @@ detekt-testUtils = { group = "io.gitlab.arturbosch.detekt", name = "detekt-test-
 assertj-core = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit5" }
 junit-platform = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit5Platform" }
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 slf4j-Api = { module = "org.slf4j:slf4j-api",  version.ref = "slfApi"}
 
 [plugins]
-kotlin-jvm = "org.jetbrains.kotlin.jvm:2.0.10"
-versions = "com.github.ben-manes.versions:0.51.0"
-intellij = "org.jetbrains.intellij:1.17.3"
-github-release = "com.github.breadmoirai.github-release:2.4.1"
+kotlin-jvm = "org.jetbrains.kotlin.jvm:2.3.0"
+versions = "com.github.ben-manes.versions:0.53.0"
+intellijPlatform = "org.jetbrains.intellij.platform:2.10.5"
+github-release = "com.github.breadmoirai.github-release:2.5.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,30 +1,29 @@
-import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
-
 rootProject.name = "detekt-intellij-plugin"
 
 // build scan plugin can only be applied in settings file
 plugins {
-    `gradle-enterprise`
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.7.2"
+    id("com.gradle.develocity") version "4.3"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.4.0"
 }
 
-gradleEnterprise {
+develocity {
     val isCiBuild = System.getenv("CI") != null
-
     buildScan {
-        publishAlways()
+        publishing {
+            onlyIf {
+                // Publish to scans.gradle.com when `--scan` is used explicitly
+                if (!gradle.startParameter.isBuildScan) {
+                    it.isAuthenticated
+                } else {
+                    true
+                }
+            }
+        }
 
-        // Publish to scans.gradle.com when `--scan` is used explicitly
         if (!gradle.startParameter.isBuildScan) {
             server = "https://ge.detekt.dev"
-            this as BuildScanExtensionWithHiddenFeatures
-            publishIfAuthenticated()
         }
 
-        isUploadInBackground = !isCiBuild
-
-        capture {
-            isTaskInputFiles = true
-        }
+        uploadInBackground = !isCiBuild
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
 
     <depends>com.intellij.modules.platform</depends>
 
-    <idea-version since-build="222.3345.118"/>
+    <idea-version since-build="223.7571.182"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Turn off error reporting for now due to https://github.com/detekt/detekt-intellij-plugin/issues/271 -->
@@ -22,6 +22,7 @@
         <projectService serviceImplementation="io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings"/>
         <projectService serviceImplementation="io.gitlab.arturbosch.detekt.idea.config.DetektSettingsMigration"/>
 
+        <!--suppress PluginXmlI18n -->
         <projectConfigurable groupId="tools"
                              displayName="detekt"
                              id="preferences.detekt"


### PR DESCRIPTION
This change upgrades the Gradle setup to the IJPL Plugin 2.x and Gradle 9.2.1 — also including upgrading all dependencies and Gradle plugins on the way (dependencies have not been upgraded to new major versions).

This requires bumping the sinceBuild from 2022.2 to 2022.3 (min version supported by the IJPL Gradle plugin 2.x), but that should not be a big issue. It also requires moving the project to the new Develocity plugin for build scans.