### PR TITLE
Implement Maven-based plugin management

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build detekt idea plugin
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --no-daemon
+        run: ./gradlew build --no-daemon --continue

--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -7,6 +7,11 @@
         <option value="$PROJECT_DIR$/config/detekt.yaml" />
       </set>
     </option>
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/config/detekt.yaml" />
+      </list>
+    </option>
     <option name="enableDetekt" value="true" />
     <option name="enableForProjectResult" value="Accepted" />
     <option name="enableFormatting" value="true" />

--- a/.run/Run Plugin.run.xml
+++ b/.run/Run Plugin.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Plugin" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/IC-*/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -18,7 +18,11 @@
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
     <method v="2" />
   </configuration>
 </component>

--- a/DETEKT_PLUGINS.md
+++ b/DETEKT_PLUGINS.md
@@ -1,0 +1,251 @@
+# Detekt Plugin Management
+
+The Detekt IntelliJ Plugin supports extending Detekt's static analysis capabilities by allowing users to
+add [third-party rule sets](https://detekt.dev/marketplace) from Maven repositories. Plugins can be added either as
+local JAR files or by searching Maven Central directly from the IDE. The system automatically resolves transitive
+dependencies, downloads required artifacts, and manages them in a project-local folder (`.idea/detektPlugins/`). Users
+can customize which transitive dependencies to include or exclude through an interactive dependency tree editor.
+
+## Architecture Overview
+
+```mermaid
+flowchart TB
+    subgraph UI["User Interface"]
+        PC[PluginsListPanel]
+        MSD[MavenSearchDialog]
+        DEE[DependencyExclusionEditor]
+    end
+
+    subgraph Logic["Core Logic"]
+        PDS[PluginDependencyService]
+        MDR[MavenDependencyResolver]
+        MTR[MavenTreeResolver]
+        DSH[DependencySelectionHandler]
+    end
+
+    subgraph Data["Data Models"]
+        DP[DetektPlugin]
+        RN[ResolvedNode]
+        PD[ProvidedDependencies]
+        SN[SyncableNode]
+    end
+
+    subgraph External["External Services"]
+        JRM[JarRepositoryManager]
+        ARM[ArtifactRepositoryManager]
+        MC[(Maven Central)]
+    end
+
+    PC --> MSD
+    MSD --> MAF[MavenArtifactFetcher]
+    MSD --> MDR
+    MSD --> DEE
+    DEE --> DSH
+    DEE --> RN
+    DSH --> SN
+    PDS --> MDR
+    MDR --> MTR
+    MTR --> JRM
+    MTR --> ARM
+    MAF --> JRM
+    JRM --> MC
+    ARM --> MC
+    PDS --> DP
+    MDR --> RN
+    MDR --> PD
+```
+
+## Component Descriptions
+
+### User Interface Layer
+
+| Component                     | File                                                                                                                    | Purpose                                                                                                         |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| **PluginsListPanel**          | [PluginsListPanel.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/PluginsListPanel.kt)                   | Main configuration panel showing the list of configured plugins. Supports both JAR files and Maven coordinates. |
+| **MavenSearchDialog**         | [MavenSearchDialog.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenSearchDialog.kt)                 | Dialog for searching Maven artifacts, selecting versions, and previewing transitive dependencies.               |
+| **DependencyExclusionEditor** | [DependencyExclusionEditor.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DependencyExclusionEditor.kt) | Tree-based editor for selectively excluding transitive dependencies from download.                              |
+| **MavenArtifactFetcher**      | [MavenArtifactFetcher.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenArtifactFetcher.kt)           | Handles artifact search and version fetching from Maven repositories.                                           |
+
+### Core Logic Layer
+
+| Component                      | File                                                                                                                         | Purpose                                                                                  |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| **PluginDependencyService**    | [PluginDependencyService.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginDependencyService.kt)               | Project-level service that orchestrates plugin downloading, reconciliation, and cleanup. |
+| **MavenDependencyResolver**    | [MavenDependencyResolver.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolver.kt)               | Resolves a Maven coordinate to its full dependency tree.                                 |
+| **MavenTreeResolver**          | [MavenTreeResolver.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenTreeResolver.kt)                           | Low-level interface to IntelliJ's Maven infrastructure.                                  |
+| **DependencySelectionHandler** | [DependencySelectionHandler.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencySelectionHandler.kt) | UI-agnostic logic for synchronizing checkbox states across the dependency tree.          |
+
+### Data Models
+
+| Component                | File                                                                                                           | Purpose                                                              |
+|--------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| **DetektPlugin**         | [DetektPlugin.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/DetektPlugin.kt)                       | Data class representing a plugin with its coordinate and exclusions. |
+| **ResolvedNode**         | [MavenDependencyResolver.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolver.kt) | Represents a node in the resolved dependency tree.                   |
+| **ProvidedDependencies** | [ProvidedDependencies.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProvidedDependencies.kt)       | Utility for identifying dependencies provided by the runtime.        |
+| **SyncableNode**         | [SyncableNode.kt](src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/SyncableNode.kt)               | Interface for dependency tree nodes that can be checked/unchecked.   |
+
+## Data Flow
+
+### Adding a Plugin from Maven
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant MSD as MavenSearchDialog
+    participant MAF as MavenArtifactFetcher
+    participant MDR as MavenDependencyResolver
+    participant DEE as DependencyExclusionEditor
+    participant PDS as PluginDependencyService
+    User ->> MSD: Opens Maven search dialog
+    User ->> MSD: Enters search query
+    MSD ->> MAF: searchArtifacts(query)
+    MAF -->> MSD: List<MavenArtifact>
+    User ->> MSD: Selects artifact and version
+    MSD ->> MDR: resolve(coordinate)
+    MDR -->> MSD: ResolvedNode tree
+    User ->> MSD: Clicks "Customize"
+    MSD ->> DEE: selectExcludedDependencies()
+    User ->> DEE: Adjusts selections
+    DEE -->> MSD: Set<exclusions>
+    User ->> MSD: Clicks OK
+    MSD -->> User: DetektPlugin
+    User ->> PDS: reconcilePlugins([plugin])
+    PDS ->> MDR: resolve(coordinate, download=true)
+    PDS ->> PDS: collectAllowedNodes()
+    PDS ->> PDS: Copy JARs to .idea/detektPlugins/
+    PDS ->> PDS: Save downloaded.json
+```
+
+#### Step-by-Step Breakdown
+
+1. **Search (`searchArtifacts`)**: The `MavenArtifactFetcher` queries Maven Central and other configured
+   repositories using IntelliJ's `JarRepositoryManager`. It returns a list of matching artifacts with all their
+   available versions pre-fetched in parallel.
+
+2. **Version Selection**: When the user selects an artifact, the dialog populates a dropdown with available versions
+   (sorted latest-first). Selecting a version triggers dependency resolution.
+
+3. **Dependency Resolution (`resolve`)**: The `MavenDependencyResolver` uses IntelliJ's Maven infrastructure to
+   fetch the full transitive dependency tree. Each node is marked as:
+    - `isProvided`: true if the dependency is provided by the runtime (e.g., kotlin-stdlib)
+    - `isRejected`: true if Maven rejected it due to version conflicts
+
+4. **Customize Dialog (`selectExcludedDependencies`)**: Opens the `DependencyExclusionEditor` showing a checkbox
+   tree of all dependencies. Users can uncheck dependencies they don't want downloaded. The
+   `DependencySelectionHandler` enforces the rules described below.
+
+5. **Plugin Creation**: When the user clicks OK, a `DetektPlugin` object is created containing the Maven coordinate
+   and the set of excluded dependency coordinates (_groupId:artifactId_ format).
+
+6. **Reconciliation (`reconcilePlugins`)**: When the settings dialog is closed, the `PluginDependencyService` is
+   called with the full list of configured plugins. This triggers the download and cleanup process.
+
+### Plugin Reconciliation and Cleanup
+
+The `PluginDependencyService.reconcilePlugins()` method runs as a background task when plugin settings are saved.
+It performs a full synchronization between the configured plugins and the local `.idea/detektPlugins/` folder.
+
+#### When Reconciliation Runs
+
+- **Settings Apply**: When the user clicks "OK" or "Apply" in the Detekt configuration panel
+- **Project Open**: When IntelliJ loads the project settings from `detekt.xml`
+- **VCS Update**: When `.idea/detekt.xml` is modified by a VCS pull/merge (IntelliJ detects the file change and
+  reloads settings via `SimplePersistentStateComponent.loadState()`)
+
+#### What Reconciliation Does
+
+1. **Resolve with Download**: Re-resolves each plugin's dependency tree with `shouldDownload = true`, which tells
+   the Maven infrastructure to download JAR files to the local Maven cache (~/.m2/repository).
+
+2. **Collect Allowed Nodes**: Traverses the resolved tree and filters out:
+    - Provided dependencies (kotlin-stdlib, detekt-api, etc.)
+    - Explicitly excluded dependencies (from user customization)
+    - Duplicate coordinates (diamond dependencies)
+
+3. **Copy Missing JARs**: For each allowed dependency, copies the JAR from the Maven cache to
+   `.idea/detektPlugins/` using a Maven-style directory structure (`groupId/artifactId/version/artifact.jar`).
+
+4. **Delete Orphaned Files**: Scans the plugin folder and deletes any JAR files that are no longer referenced
+   by any configured plugin. This happens when:
+    - A plugin is removed from the configuration
+    - A plugin's version is changed
+    - A transitive dependency is newly excluded
+
+5. **Clean Empty Directories**: After deleting orphaned JARs, removes any empty directories (bottom-up traversal).
+
+6. **Save State**: Writes `downloaded.json` with the current state of all plugins and their transitive dependencies.
+
+7. **Restart Analysis**: Calls `DaemonCodeAnalyzer.restart()` to make IntelliJ pick up the new plugins immediately.
+
+### Dependency Selection Rules
+
+The `DependencySelectionHandler` implements these rules for checkbox synchronization:
+
+1. **Provided Protection**: Nodes marked as "provided" (e.g., kotlin-stdlib, detekt-api) cannot be unchecked
+2. **Global Sync**: All occurrences of the same artifact (groupId:artifactId) sync to the same state
+3. **Children Propagation**: Unchecking a parent unchecks all non-provided children
+4. **Parent Propagation**: Checking a child checks all ancestors
+
+## Version control
+
+The `.idea/detektPlugins/` folder contains downloaded JARs and should **not** be committed to version control. Add it to
+your VCS ignore file (e.g., `.gitignore`) so that only plugin configuration in `detekt.xml` is tracked; other
+developers and CI will re-download artifacts when they open the project or apply settings.
+
+- **Git**: ensure `.idea/detektPlugins/` is in `.gitignore`
+- **Other VCS**: add the equivalent ignore rule for `.idea/detektPlugins/`.
+
+## File Structure
+
+After downloading plugins, the `.idea/detektPlugins/` folder contains:
+
+```
+.idea/detektPlugins/
+├── downloaded.json                    # Tracking file
+├── io/
+│   └── nlopez/
+│       └── compose/
+│           └── rules/
+│               └── detekt/
+│                   └── 0.4.22/
+│                       └── detekt-0.4.22.jar
+└── com/
+    └── example/
+        └── some-rule/
+            └── 1.0.0/
+                └── some-rule-1.0.0.jar
+```
+
+The `downloaded.json` file tracks the state:
+
+```json
+{
+  "plugins": [
+    {
+      "coordinate": "io.nlopez.compose.rules:detekt:0.4.22",
+      "transitiveDependencies": [
+        "com.example:some-rule:1.0.0"
+      ],
+      "path": "io/nlopez/compose/rules/detekt/0.4.22/detekt-0.4.22.jar"
+    }
+  ],
+  "transitiveFiles": {
+    "com.example:some-rule:1.0.0": {
+      "path": "com/example/some-rule/1.0.0/some-rule-1.0.0.jar"
+    }
+  }
+}
+```
+
+## Provided Dependencies
+
+The following dependency groups are automatically excluded from downloads because they are provided by the
+detekt-intellij-plugin runtime:
+
+- `io.gitlab.arturbosch.detekt:*`
+- `dev.detekt:*`
+- `org.jetbrains.kotlin:*`
+- `org.jetbrains.kotlinx:kotlinx-coroutines-*`
+
+These appear as "(provided)" in the dependency tree UI and cannot be unchecked. They are not downloaded as it is assumed
+that the detekt IDE plugin already provides these dependencies on the classpath.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Integrates _detekt_, a static code analysis tool for the Kotlin programming lang
 
 ![detekt in action](./img/detekt.png "detekt in action")
 
-The plugin can be downloaded from the [Jetbrains plugin repository](https://plugins.jetbrains.com/plugin/10761-detekt).
+The plugin can be downloaded from the [JetBrains plugin repository](https://plugins.jetbrains.com/plugin/10761-detekt).
 
 ## Enabling the plugin
 
@@ -29,6 +29,15 @@ The plugin can be downloaded from the [Jetbrains plugin repository](https://plug
 
 That's it. Detekt issues will be annotated on-the-fly while coding.
 
+## Third-Party Plugins
+
+You can extend Detekt with third-party rule sets directly from the configuration panel. Add plugins as local JAR files
+or search Maven Central for published rule sets. The plugin handles dependency resolution and management automatically.
+Do not commit the `.idea/detektPlugins/` folder (it is in `.gitignore`); see [DETEKT_PLUGINS.md](DETEKT_PLUGINS.md) for
+details.
+
+For technical details about the plugin mechanism, see [DETEKT_PLUGINS.md](DETEKT_PLUGINS.md).
+
 ## Autocorrection
 
 You may optionally click `Refactor` -> `AutoCorrect by detekt rules` to auto correct detekt violations if possible.
@@ -45,7 +54,9 @@ is used.
 gradlew buildPlugin
 ```
 
-To test your development, use task `runIde` which will automatically run an Intellij instance to test your new version of detekt plugin.
+To test your development, use task `runIde` which will automatically run an Intellij instance to test your new version
+of the detekt plugin.
+
 ```bash
 # linux & macOS
 ./gradlew runIde
@@ -53,4 +64,4 @@ To test your development, use task `runIde` which will automatically run an Inte
 gradlew runIde
 ```
 
-Also install the current `Detekt IntelliJ Plugin` version  to verify you do not introduce new issues.
+Also install the current `Detekt IntelliJ Plugin` version to verify you do not introduce new issues.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,12 @@ dependencies {
         }
     }
 
-    implementation(libs.detekt.api)
-    implementation(libs.detekt.tooling)
+    implementation(libs.detekt.api) { exclude(group = "org.jetbrains.kotlinx") }
+    implementation(libs.detekt.tooling) { exclude(group = "org.jetbrains.kotlinx") }
 
-    runtimeOnly(libs.detekt.core)
-    runtimeOnly(libs.detekt.rules)
-    runtimeOnly(libs.detekt.formatting)
+    runtimeOnly(libs.detekt.core) { exclude(group = "org.jetbrains.kotlinx") }
+    runtimeOnly(libs.detekt.rules) { exclude(group = "org.jetbrains.kotlinx") }
+    runtimeOnly(libs.detekt.formatting) { exclude(group = "org.jetbrains.kotlinx") }
 
     testImplementation(libs.detekt.testUtils)
     testImplementation(libs.assertj.core)
@@ -40,11 +40,12 @@ dependencies {
     testRuntimeOnly(libs.junit4)
 
     intellijPlatform {
-        intellijIdeaCommunity("2022.3")
+        intellijIdeaCommunity("2024.2")
 
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.intellij.intelliLang")
         bundledPlugin("org.jetbrains.kotlin")
+        bundledPlugin("org.jetbrains.idea.maven")
 
         testFramework(TestFrameworkType.Platform)
 
@@ -53,7 +54,7 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 tasks.withType<Test>().configureEach {
@@ -72,7 +73,12 @@ tasks.publishPlugin {
     token.set((findProperty("intellijPublishToken") as? String).orEmpty())
     // https://plugins.jetbrains.com/docs/intellij/publishing-plugin.html#specifying-a-release-channel
     // "-beta" is used for pre-releases and https://plugins.jetbrains.com/plugins/beta/list as plugin repository.
-    channels.set(listOf(project.version.toString().split('-').getOrElse(1) { "default" }.split('.').first()))
+    val channelName = project.version.toString()
+        .split('-')
+        .getOrElse(1) { "default" }
+        .split('.')
+        .first()
+    channels.set(listOf(channelName))
 }
 
 intellijPlatform {
@@ -85,7 +91,9 @@ intellijPlatform {
     }
 
     pluginVerification {
-        ides { recommended() }
+        ides {
+            recommended()
+        }
     }
 }
 

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredService.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredService.kt
@@ -16,6 +16,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.UnstableApi
 import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings
 import io.gitlab.arturbosch.detekt.idea.util.DirectExecutor
+import io.gitlab.arturbosch.detekt.idea.util.PluginDependencyService
 import io.gitlab.arturbosch.detekt.idea.util.PluginUtils
 import io.gitlab.arturbosch.detekt.idea.util.SimpleAppendable
 import io.gitlab.arturbosch.detekt.idea.util.absoluteBaselinePath
@@ -26,6 +27,10 @@ import java.nio.file.Paths
 import kotlin.io.path.Path
 import kotlin.io.path.exists
 
+/**
+ * Service responsible for configuring and executing detekt analysis. It handles path validation, setting up
+ * [ProcessingSpec], and running detekt either on a [PsiFile] or direct file content.
+ */
 class ConfiguredService(private val project: Project) {
 
     private val logger = logger<ConfiguredService>()
@@ -33,6 +38,11 @@ class ConfiguredService(private val project: Project) {
 
     private val projectBasePath = project.basePath?.let(::Path)
 
+    /**
+     * Validates the current detekt configuration. Checks if plugin JARs and configuration files exist.
+     *
+     * @return A list of error messages, or an empty list if validation passes.
+     */
     fun validate(): List<String> {
         val messages = mutableListOf<String>()
 
@@ -97,12 +107,27 @@ class ConfiguredService(private val project: Project) {
             .asAbsolutePaths()
             .toList()
 
-    private fun pluginPaths(): List<Path> =
-        settings.pluginJarPaths
+    /**
+     * Returns a list of paths to all detekt plugin JARs, including those configured manually and those downloaded via
+     * Maven.
+     */
+    internal fun pluginPaths(): List<Path> {
+        val configured = settings.pluginJarPaths
             .asSequence()
             .filter { it.isNotBlank() }
             .asAbsolutePaths()
             .toList()
+
+        val downloadedFolder = project.service<PluginDependencyService>().getPluginFolder()
+        val downloaded =
+            if (downloadedFolder.exists()) {
+                Files.walk(downloadedFolder).use { stream -> stream.filter { it.toString().endsWith(".jar") }.toList() }
+            } else {
+                emptyList()
+            }
+
+        return configured + downloaded
+    }
 
     private fun Sequence<String>.asAbsolutePaths() =
         map { it.replace('/', File.separatorChar) }
@@ -110,16 +135,20 @@ class ConfiguredService(private val project: Project) {
 
     private fun baseline(): Path? = absoluteBaselinePath(project, settings)
 
+    /**
+     * Executes detekt analysis on the provided [PsiFile].
+     *
+     * @param file The file to analyze.
+     * @param autoCorrect Whether detekt should attempt to automatically fix issues.
+     * @return A list of [Finding]s found by detekt.
+     */
     fun execute(file: PsiFile, autoCorrect: Boolean): List<Finding> {
         val pathToAnalyze = file.virtualFile
             ?.canonicalPath
             ?: return emptyList()
         val content = runCatching { runReadAction { file.text } }
             .onFailure {
-                logErrorIfAllowed(
-                    it,
-                    "Unexpected error while reading file content: ${file.virtualFile.path}"
-                )
+                logErrorIfAllowed(it, "Unexpected error while reading file content: ${file.virtualFile.path}")
             }
             .getOrThrow()
         return runCatching { execute(content, pathToAnalyze, autoCorrect) }
@@ -134,6 +163,14 @@ class ConfiguredService(private val project: Project) {
         logger.error(message, error)
     }
 
+    /**
+     * Executes detekt analysis on the provided file content.
+     *
+     * @param fileContent The content of the file to analyze.
+     * @param filename The name of the file (used for rules matching).
+     * @param autoCorrect Whether detekt should attempt to automatically fix issues.
+     * @return A list of [Finding]s reported by detekt.
+     */
     @OptIn(UnstableApi::class)
     fun execute(fileContent: String, filename: String, autoCorrect: Boolean): List<Finding> {
         if (filename in SPECIAL_FILES_TO_IGNORE) {

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektProjectManagerListener.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/DetektProjectManagerListener.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings.EnableForPro
 
 class DetektProjectManagerListener : ProjectManagerListener {
 
+    @Deprecated("")
     override fun projectOpened(project: Project) {
         val settings = project.service<DetektPluginSettings>()
 

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/DetektConfig.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/DetektConfig.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.idea.config
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import io.gitlab.arturbosch.detekt.idea.DetektBundle
 import io.gitlab.arturbosch.detekt.idea.config.ui.DetektConfigUi
+import io.gitlab.arturbosch.detekt.idea.util.PluginDependencyService
 
 class DetektConfig(private val project: Project) : BoundSearchableConfigurable(
     displayName = DetektBundle.message("detekt.configuration.title"),
@@ -16,12 +16,10 @@ class DetektConfig(private val project: Project) : BoundSearchableConfigurable(
 
     private val settings = project.service<DetektPluginSettings>()
 
-    override fun createPanel(): DialogPanel {
-        return DetektConfigUi(settings, project).createPanel()
-    }
+    override fun createPanel(): DialogPanel = DetektConfigUi(settings, project).createPanel()
 
     override fun apply() {
         super.apply()
-        DaemonCodeAnalyzer.getInstance(project).restart()
+        project.service<PluginDependencyService>().reconcilePlugins(settings.plugins)
     }
 }

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencySelectionHandler.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencySelectionHandler.kt
@@ -1,0 +1,97 @@
+package io.gitlab.arturbosch.detekt.idea.config.logic
+
+/**
+ * Handles the synchronization and propagation logic for dependency selection.
+ */
+object DependencySelectionHandler {
+
+    /**
+     * Synchronizes selection state for the given [node] across [allNodes] and propagates changes to relatives.
+     * Propagation rules are based on JPS' UI's rules, plus adjustments to deal with always-selected provided nodes.
+     *
+     * Rules implemented:
+     * 1. **Provided Protection**: provided nodes cannot be unchecked.
+     * 2. **Global Sync**: all nodes with the same G:A as [node] update to the new state.
+     * 3. **Children Propagation**: if [node] is toggled, all children update to match (respecting provided protection).
+     * 4. **Parent Propagation**: if [node] is checked, all ancestors are checked (unless [node] is provided).
+     */
+    fun syncArtifacts(
+        node: SyncableNode,
+        allNodes: Iterable<SyncableNode>,
+        setNodeState: (SyncableNode, Boolean) -> Unit,
+    ) {
+        // 1. Provided Node Protection: force provided nodes to stay checked
+        if (node.isProvided) {
+            if (!node.isChecked) {
+                setNodeState(node, true)
+            }
+            // Provided nodes are static and should not be sources of propagation
+            return
+        }
+
+        val mavenCoordinate = node.mavenCoordinate
+        val newState = node.isChecked
+
+        // 2. Global Synchronization: sync all occurrences of the same artifact
+        synchronize(allNodes, mavenCoordinate, newState, setNodeState)
+
+        // 3. Children Propagation: recursively update the state of all descendants
+        propagateToChildren(node, newState, setNodeState)
+
+        // 4. Parent Propagation: if checked, recursively ensure all ancestors are checked
+        propagateToParent(newState, node, setNodeState)
+    }
+
+    private fun synchronize(
+        allNodes: Iterable<SyncableNode>,
+        mavenCoordinate: String,
+        newState: Boolean,
+        setNodeState: (SyncableNode, Boolean) -> Unit,
+    ) {
+        for (treeNode in allNodes) {
+            val matchingCoordinates = treeNode.mavenCoordinate == mavenCoordinate
+            val isNowCheckedOrNotProvided = newState || !treeNode.isProvided
+            val checkedChanged = treeNode.isChecked != newState
+            if (matchingCoordinates && isNowCheckedOrNotProvided && checkedChanged) {
+                setNodeState(treeNode, newState)
+            }
+        }
+    }
+
+    private fun propagateToChildren(
+        node: SyncableNode,
+        newState: Boolean,
+        setNodeState: (SyncableNode, Boolean) -> Unit,
+        visited: Set<SyncableNode> = emptySet(),
+    ) {
+        if (visited.contains(node)) return // Prevent loops
+        val newVisited = visited + node
+
+        for (child in node.children) {
+            if (newState) {
+                setNodeState(child, true)
+            } else if (!child.isProvided) {
+                setNodeState(child, false)
+            }
+
+            // Provided children stay checked when unchecking parent
+            propagateToChildren(child, newState, setNodeState, newVisited)
+        }
+    }
+
+    private fun propagateToParent(
+        newState: Boolean,
+        node: SyncableNode,
+        setNodeState: (SyncableNode, Boolean) -> Unit,
+    ) {
+        if (newState) {
+            var parent = node.parent
+            while (parent != null) {
+                if (!parent.isChecked) {
+                    setNodeState(parent, true)
+                }
+                parent = parent.parent
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/SyncableNode.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/SyncableNode.kt
@@ -1,0 +1,47 @@
+package io.gitlab.arturbosch.detekt.idea.config.logic
+
+/**
+ * Interface for a node that can be synchronized and propagated in a dependency tree.
+ */
+interface SyncableNode {
+    /**
+     * The Maven group ID of the dependency.
+     */
+    val groupId: String
+
+    /**
+     * The Maven artifact ID of the dependency.
+     */
+    val artifactId: String
+
+    /**
+     * Whether this dependency is provided by the platform and cannot be unchecked.
+     */
+    val isProvided: Boolean
+
+    /**
+     * Whether this dependency is currently checked for download.
+     */
+    var isChecked: Boolean
+
+    /**
+     * The parent node in the dependency tree, or null if this is a root node.
+     */
+    val parent: SyncableNode?
+
+    /**
+     * The list of children (transitive dependencies) of this node.
+     */
+    val children: Iterable<SyncableNode>
+
+    /**
+     * Updates the checked state of this node. In a UI implementation, this should update the underlying checkbox.
+     */
+    fun updateChecked(checked: Boolean)
+
+    /**
+     * The Maven coordinates ([groupId]:[artifactId]) of the dependency.
+     */
+    val mavenCoordinate: String
+        get() = "$groupId:$artifactId"
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DependencyExclusionEditor.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DependencyExclusionEditor.kt
@@ -1,0 +1,273 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import com.intellij.ide.JavaUiBundle
+import com.intellij.openapi.ui.DialogBuilder
+import com.intellij.ui.CheckboxTree
+import com.intellij.ui.CheckboxTreeBase
+import com.intellij.ui.CheckboxTreeListener
+import com.intellij.ui.CheckedTreeNode
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.TreeUIHelper
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.NamedColorUtil
+import com.intellij.util.ui.tree.TreeUtil
+import io.gitlab.arturbosch.detekt.idea.DetektBundle
+import io.gitlab.arturbosch.detekt.idea.config.logic.DependencySelectionHandler
+import io.gitlab.arturbosch.detekt.idea.config.logic.SyncableNode
+import io.gitlab.arturbosch.detekt.idea.util.MavenDependencyResolver
+import org.jetbrains.annotations.VisibleForTesting
+import java.awt.Component
+import javax.swing.JTree
+
+/**
+ * A dialog for excluding dependencies from download in detekt plugins.
+ *
+ * @param root The root node of the dependency tree.
+ * @param parentComponent The Swing component that will be the parent of this dialog.
+ */
+internal class DependencyExclusionEditor(
+    root: MavenDependencyResolver.ResolvedNode,
+    private val parentComponent: Component,
+) {
+    private val dependenciesTree = DependenciesTree(root) { node -> syncArtifacts(node) }
+
+    private val allNodesCache: List<CheckedTreeNodeAdapter> by lazy {
+        TreeUtil.treeNodeTraverser(dependenciesTree.rootNode)
+            .filter(CheckedTreeNode::class.java)
+            .map(::CheckedTreeNodeAdapter)
+            .toList()
+    }
+
+    /**
+     * Opens a dialog to allow the user to select which transitive dependencies to exclude.
+     *
+     * @param initialExclusions The set of initially excluded dependency coordinates.
+     * @return The updated set of excluded dependency coordinates, or null if the user cancelled.
+     */
+    fun selectExcludedDependencies(initialExclusions: Set<String>): Set<String>? {
+        uncheckExcludedNodes(dependenciesTree.rootNode, initialExclusions, false)
+        TreeUtil.expandAll(dependenciesTree)
+
+        val dialogBuilder =
+            DialogBuilder(parentComponent)
+                .title(JavaUiBundle.message("dialog.title.include.transitive.dependencies"))
+                .centerPanel(JBScrollPane(dependenciesTree))
+
+        dialogBuilder.setPreferredFocusComponent(dependenciesTree)
+
+        return if (dialogBuilder.showAndGet()) {
+            val result = mutableSetOf<String>()
+            collectUncheckedNodes(dependenciesTree.rootNode, result)
+            result
+        } else {
+            null
+        }
+    }
+
+    private fun uncheckExcludedNodes(node: CheckedTreeNode, excluded: Set<String>, parentIsExcluded: Boolean) {
+        val isExcluded = parentIsExcluded || excluded.contains(node.mavenCoordinate)
+        node.isChecked = !isExcluded || node.isProvided
+        node.children().asSequence().filterIsInstance<CheckedTreeNode>().forEach {
+            uncheckExcludedNodes(it, excluded, isExcluded)
+        }
+    }
+
+    private fun collectUncheckedNodes(node: CheckedTreeNode, result: MutableSet<String>) {
+        if (node.isChecked) {
+            node.children().asSequence()
+                .filterIsInstance<CheckedTreeNode>()
+                .forEach { collectUncheckedNodes(it, result) }
+        } else {
+            result.add(node.mavenCoordinate)
+        }
+    }
+
+    private fun syncArtifacts(node: CheckedTreeNode) {
+        DependencySelectionHandler.syncArtifacts(CheckedTreeNodeAdapter(node), allNodesCache) { syncable, state ->
+            syncable.updateChecked(state)
+        }
+    }
+
+    /**
+     * An adapter that allows a [CheckedTreeNode] to be used with the [DependencySelectionHandler].
+     */
+    private inner class CheckedTreeNodeAdapter(val node: CheckedTreeNode) : SyncableNode {
+
+        override val groupId: String
+            get() = node.resolvedNode.groupId
+
+        override val artifactId: String
+            get() = node.resolvedNode.artifactId
+
+        override val isProvided: Boolean
+            get() = node.resolvedNode.isProvided
+
+        override var isChecked: Boolean
+            get() = node.isChecked
+            set(value) {
+                node.isChecked = value
+            }
+
+        override val parent: SyncableNode?
+            get() = (node.parent as? CheckedTreeNode)?.let { CheckedTreeNodeAdapter(it) }
+
+        override val children: Iterable<SyncableNode>
+            get() =
+                node
+                    .children()
+                    .asSequence()
+                    .filterIsInstance<CheckedTreeNode>()
+                    .map { CheckedTreeNodeAdapter(it) }
+                    .asIterable()
+
+        override fun updateChecked(checked: Boolean) {
+            dependenciesTree.setNodeState(node, checked)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is CheckedTreeNodeAdapter) return false
+            return node == other.node
+        }
+
+        override fun hashCode(): Int = node.hashCode()
+    }
+
+    companion object {
+        private val CheckedTreeNode.mavenCoordinate: String
+            get() = "${resolvedNode.groupId}:${resolvedNode.artifactId}"
+
+        private val CheckedTreeNode.isProvided: Boolean
+            get() = resolvedNode.isProvided
+
+        private val CheckedTreeNode.resolvedNode: MavenDependencyResolver.ResolvedNode
+            get() = userObject as MavenDependencyResolver.ResolvedNode
+    }
+}
+
+// We need to handle this ourselves so we can deal with provided nodes properly.
+// If we let the component deal with any of these, we end up in broken states.
+private val checkboxCheckPolicy =
+    CheckboxTreeBase.CheckPolicy(
+        false, // checkChildrenWithCheckedParent
+        false, // uncheckChildrenWithUncheckedParent
+        false, // checkParentWithCheckedChild
+        false, // uncheckParentWithUncheckedChild
+    )
+
+/**
+ * A specialized [CheckboxTree] for displaying and managing Maven dependencies.
+ */
+private class DependenciesTree(
+    root: MavenDependencyResolver.ResolvedNode,
+    onNodeStateChanged: (CheckedTreeNode) -> Unit,
+) : CheckboxTree(Renderer(), buildDependencyTreeNode(root), checkboxCheckPolicy) {
+    val rootNode: CheckedTreeNode
+        get() = model.root as CheckedTreeNode
+
+    init {
+        isRootVisible = false
+        addCheckboxTreeListener(
+            object : CheckboxTreeListener {
+                private var processingNodes = false
+
+                override fun nodeStateChanged(node: CheckedTreeNode) {
+                    if (processingNodes) return
+                    processingNodes = true
+                    try {
+                        onNodeStateChanged(node)
+                    } finally {
+                        processingNodes = false
+                    }
+                }
+            }
+        )
+    }
+
+    override fun installSpeedSearch() {
+        TreeUIHelper.getInstance()
+            .installTreeSpeedSearch(
+                this,
+                { treePath ->
+                    val node = treePath.lastPathComponent as? CheckedTreeNode
+                    val data = node?.userObject as? MavenDependencyResolver.ResolvedNode
+                    data?.coordinate ?: ""
+                },
+                true,
+            )
+    }
+
+    /**
+     * A renderer for [DependenciesTree] that handles coordinate formatting and status (rejected, provided).
+     *
+     * We pass `false` for usePartialStatusForParentNodes because we want parent nodes to show their own checked state,
+     * not inherit the state from their children. This is important when a parent is unchecked but all its children
+     * (provided deps) are forced to stay checked.
+     */
+    private class Renderer :
+        CheckboxTreeCellRenderer(
+            true, // opaque
+            false, // usePartialStatusForParentNodes
+        ) {
+        override fun customizeRenderer(
+            tree: JTree,
+            value: Any,
+            selected: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean,
+        ) {
+            val node = (value as? CheckedTreeNode)?.userObject as? MavenDependencyResolver.ResolvedNode ?: return
+
+            val (attributes, grayedAttributes) =
+                if (node.isRejected) {
+                    STRIKEOUT_ATTRIBUTES to STRIKEOUT_GRAYED_ATTRIBUTES
+                } else {
+                    SimpleTextAttributes.REGULAR_ATTRIBUTES to SimpleTextAttributes.GRAYED_ATTRIBUTES
+                }
+
+            if (node.isProvided) {
+                textRenderer.append("(provided) ", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+            }
+            textRenderer.append("${node.groupId}:${node.artifactId}", attributes, true)
+            textRenderer.append(":${node.version}", grayedAttributes, true)
+
+            toolTipText =
+                when {
+                    node.isProvided -> DetektBundle.message("tooltip.text.dependency.is.provided")
+                    node.isRejected -> JavaUiBundle.message("tooltip.text.dependency.was.rejected")
+                    else -> null
+                }
+        }
+    }
+
+    companion object {
+        private val STRIKEOUT_ATTRIBUTES = SimpleTextAttributes(SimpleTextAttributes.STYLE_STRIKEOUT, null)
+        private val STRIKEOUT_GRAYED_ATTRIBUTES =
+            SimpleTextAttributes(SimpleTextAttributes.STYLE_STRIKEOUT, NamedColorUtil.getInactiveTextColor())
+
+        // Node building is handled by buildDependencyTreeNode to keep it testable.
+    }
+}
+
+@VisibleForTesting
+internal fun buildDependencyTreeNode(
+    node: MavenDependencyResolver.ResolvedNode,
+    visited: Set<String> = emptySet(),
+): CheckedTreeNode {
+    val treeNode = CheckedTreeNode(node)
+    treeNode.isEnabled = !node.isProvided
+    treeNode.isChecked = true
+
+    if (visited.contains(node.coordinate)) {
+        treeNode.isEnabled = false
+        return treeNode
+    }
+
+    val nextVisited = visited + node.coordinate
+    for (dependency in node.children) {
+        treeNode.add(buildDependencyTreeNode(dependency, nextVisited))
+    }
+    return treeNode
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DetektConfigUi.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DetektConfigUi.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.observable.util.bindEnabled
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.BottomGap
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.MutableProperty
@@ -14,11 +16,10 @@ import com.intellij.ui.dsl.builder.RowLayout
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.ui.layout.selected
 import io.gitlab.arturbosch.detekt.idea.DetektBundle
 import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings
+import io.gitlab.arturbosch.detekt.idea.util.DetektPlugin
 import io.gitlab.arturbosch.detekt.idea.util.toPathsList
 import io.gitlab.arturbosch.detekt.idea.util.toVirtualFilesList
 import io.gitlab.arturbosch.detekt.idea.util.validateAsFilePath
@@ -31,7 +32,6 @@ internal class DetektConfigUi(
     private val settings: DetektPluginSettings,
     private val project: Project,
 ) {
-
     fun createPanel(): DialogPanel = panel {
         lateinit var detektEnabledCheckbox: JCheckBox
         row {
@@ -55,7 +55,7 @@ internal class DetektConfigUi(
     private fun Panel.pluginOptionsGroup() =
         group(
             title = DetektBundle.message("detekt.configuration.pluginGroup.title"),
-            indent = false
+            indent = false,
         ) {
             row {
                 checkBox(DetektBundle.message("detekt.configuration.treatAsErrors"))
@@ -105,13 +105,13 @@ internal class DetektConfigUi(
 
             baselineFileRow()
 
-            pluginJarsRow(isEnabled)
+            pluginsRow(isEnabled)
         }
 
     private fun Panel.configurationFilesRow(isEnabled: ObservableProperty<Boolean>) {
         row {
             val label = label(DetektBundle.message("detekt.configuration.configurationFiles.title"))
-                .verticalAlign(VerticalAlign.TOP)
+                .align(AlignY.TOP)
                 .component
 
             val listModel = FilesListPanel.ListModel()
@@ -120,15 +120,15 @@ internal class DetektConfigUi(
                 project = project,
                 fileChooserTitle = DetektBundle.message("detekt.configuration.configurationFiles.dialog.title"),
                 fileChooserDescription =
-                DetektBundle.message("detekt.configuration.configurationFiles.dialog.description"),
-                descriptorProvider = { FileChooserDescriptorUtil.createYamlChooserDescriptor() }
+                    DetektBundle.message("detekt.configuration.configurationFiles.dialog.description"),
+                descriptorProvider = { FileChooserDescriptorUtil.createYamlChooserDescriptor() },
             ).decorated()
                 .bindEnabled(isEnabled)
 
             cell(filesListPanel)
-                .horizontalAlign(HorizontalAlign.FILL)
+                .align(AlignX.FILL)
                 .resizableColumn()
-                .bindItems(settings::configurationFilePaths, listModel)
+                .bindConfigFiles(settings::configurationFilePaths, listModel)
 
             label.labelFor = filesListPanel
         }.layout(RowLayout.LABEL_ALIGNED)
@@ -138,65 +138,7 @@ internal class DetektConfigUi(
         }.bottomGap(BottomGap.MEDIUM)
     }
 
-    private fun Panel.baselineFileRow() {
-        row(DetektBundle.message("detekt.configuration.baselineFile.title")) {
-            textFieldWithBrowseButton(
-                DetektBundle.message("detekt.configuration.baselineFile.dialog.title"),
-                project,
-                FileChooserDescriptorUtil.createSingleXmlChooserDescriptor()
-            )
-                .bindText(
-                    getter = { LocalFileSystem.getInstance().extractPresentableUrl(settings.baselinePath) },
-                    setter = {
-                        if (File(it).isFile) {
-                            settings.baselinePath = LocalFileSystem.getInstance().findFileByPath(it)?.path.orEmpty()
-                        } else {
-                            settings.baselinePath = ""
-                        }
-                    }
-                )
-                .horizontalAlign(HorizontalAlign.FILL)
-                .resizableColumn()
-                .validationOnInput { validateAsFilePath(it.text, isWarning = true) }
-                .validationOnApply { validateAsFilePath(it.text) }
-        }
-
-        row("") {
-            comment(DetektBundle.message("detekt.configuration.baselineFile.comment"))
-        }.bottomGap(BottomGap.MEDIUM)
-    }
-
-    private fun Panel.pluginJarsRow(isEnabled: ObservableProperty<Boolean>) {
-        row {
-            val label = label(DetektBundle.message("detekt.configuration.pluginJarFiles.title"))
-                .verticalAlign(VerticalAlign.TOP)
-                .component
-
-            val listModel = FilesListPanel.ListModel(settings.pluginJarPaths.toVirtualFilesList())
-            val filesListPanel = FilesListPanel(
-                listModel = listModel,
-                project = project,
-                fileChooserTitle = DetektBundle.message("detekt.configuration.pluginJarFiles.dialog.title"),
-                fileChooserDescription =
-                DetektBundle.message("detekt.configuration.pluginJarFiles.dialog.description"),
-                descriptorProvider = { FileChooserDescriptorUtil.createJarsChooserDescriptor() }
-            ).decorated()
-                .bindEnabled(isEnabled)
-
-            cell(filesListPanel)
-                .horizontalAlign(HorizontalAlign.FILL)
-                .resizableColumn()
-                .bindItems(settings::pluginJarPaths, listModel)
-
-            label.labelFor = filesListPanel
-        }.layout(RowLayout.LABEL_ALIGNED)
-
-        row("") {
-            comment(DetektBundle.message("detekt.configuration.pluginJarFiles.comment"))
-        }
-    }
-
-    private fun Cell<JPanel>.bindItems(
+    private fun Cell<JPanel>.bindConfigFiles(
         fileListProperty: KMutableProperty0<List<String>>,
         listModel: FilesListPanel.ListModel,
     ) {
@@ -207,9 +149,101 @@ internal class DetektConfigUi(
                 listModel += virtualFiles
             },
             MutableProperty(
-                { fileListProperty.get().toVirtualFilesList() },
-                { fileListProperty.set(it.toPathsList()) }
+                getter = { fileListProperty.get().toVirtualFilesList() },
+                setter = { fileListProperty.set(it.toPathsList()) },
+            ),
+        )
+    }
+
+    private fun Panel.baselineFileRow() {
+        row(DetektBundle.message("detekt.configuration.baselineFile.title")) {
+            textFieldWithBrowseButton(
+                DetektBundle.message("detekt.configuration.baselineFile.dialog.title"),
+                project,
+                FileChooserDescriptorUtil.createSingleXmlChooserDescriptor(),
             )
+                .bindText(
+                    getter = { LocalFileSystem.getInstance().extractPresentableUrl(settings.baselinePath) },
+                    setter = {
+                        if (File(it).isFile) {
+                            settings.baselinePath = LocalFileSystem.getInstance().findFileByPath(it)?.path.orEmpty()
+                        } else {
+                            settings.baselinePath = ""
+                        }
+                    },
+                )
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .validationOnInput { validateAsFilePath(it.text, isWarning = true) }
+                .validationOnApply { validateAsFilePath(it.text) }
+        }
+
+        row("") {
+            comment(DetektBundle.message("detekt.configuration.baselineFile.comment"))
+        }.bottomGap(BottomGap.MEDIUM)
+    }
+
+    private fun Panel.pluginsRow(isEnabled: ObservableProperty<Boolean>) {
+        row {
+            val label = label(DetektBundle.message("detekt.configuration.plugins.title"))
+                .align(AlignY.TOP)
+                .component
+
+            val pluginJars = settings.pluginJarPaths.toVirtualFilesList()
+                .map { PluginSpec.Jar(it) }
+            val mavenPlugins = settings.plugins.map { PluginSpec.Maven(it) }
+            val initialItems = pluginJars + mavenPlugins
+
+            val listModel = PluginsListPanel.PluginListModel(initialItems)
+            val pluginsListPanel = PluginsListPanel(listModel = listModel, project = project)
+                .decorated()
+                .bindEnabled(isEnabled)
+
+            cell(pluginsListPanel)
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .bindPlugins(settings::pluginJarPaths, settings::plugins, listModel)
+
+            label.labelFor = pluginsListPanel
+        }.layout(RowLayout.LABEL_ALIGNED)
+
+        row("") {
+            comment(DetektBundle.message("detekt.configuration.plugins.comment"))
+        }
+    }
+
+    private fun Cell<JPanel>.bindPlugins(
+        jarPathsProperty: KMutableProperty0<List<String>>,
+        pluginsProperty: KMutableProperty0<List<DetektPlugin>>,
+        listModel: PluginsListPanel.PluginListModel,
+    ) {
+        bind(
+            componentGet = { listModel.items },
+            componentSet = { _, items ->
+                listModel.clear()
+                listModel += items
+            },
+            prop = MutableProperty(
+                getter = {
+                    val jars = jarPathsProperty.get()
+                        .toVirtualFilesList()
+                        .map { PluginSpec.Jar(it) }
+                    val mavenPlugins = pluginsProperty.get()
+                        .map { PluginSpec.Maven(it) }
+
+                    jars + mavenPlugins
+                },
+                setter = { items ->
+                    val jars = items.filterIsInstance<PluginSpec.Jar>()
+                        .map { it.file }
+                        .toPathsList()
+                    val mavenPlugin = items.filterIsInstance<PluginSpec.Maven>()
+                        .map { it.plug }
+
+                    jarPathsProperty.set(jars)
+                    pluginsProperty.set(mavenPlugin)
+                },
+            ),
         )
     }
 

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/FilesListPanel.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/FilesListPanel.kt
@@ -10,21 +10,23 @@ import com.intellij.openapi.vcs.changes.ui.VirtualFileListCellRenderer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
+import java.awt.GraphicsEnvironment
 import javax.swing.DefaultListModel
 import javax.swing.JPanel
 import javax.swing.ListSelectionModel
 
-@Suppress("UnstableApiUsage") // For NlsContexts annotations
 internal class FilesListPanel(
     private val listModel: ListModel,
     private val project: Project,
-    @DialogTitle private val fileChooserTitle: String,
+    @get:DialogTitle private val fileChooserTitle: String,
     @Label private val fileChooserDescription: String,
-    private val descriptorProvider: () -> FileChooserDescriptor
+    private val descriptorProvider: () -> FileChooserDescriptor,
 ) {
 
     private val list = JBList(listModel).apply {
-        dragEnabled = true
+        if (!GraphicsEnvironment.isHeadless()) {
+            dragEnabled = true
+        }
         selectionModel.selectionMode = ListSelectionModel.MULTIPLE_INTERVAL_SELECTION
         cellRenderer = VirtualFileListCellRenderer(project)
     }

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenArtifactFetcher.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenArtifactFetcher.kt
@@ -1,0 +1,438 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import com.intellij.jarRepository.JarRepositoryManager
+import com.intellij.jarRepository.RepositoryArtifactDescription
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.text.VersionComparatorUtil
+import io.gitlab.arturbosch.detekt.idea.util.MIN_COORDINATES_PARTS
+import org.jetbrains.annotations.VisibleForTesting
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryDescription
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties
+import java.util.concurrent.Callable
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Default timeout for synchronous version fetching operations.
+ */
+private val MAVEN_FETCH_REQUEST_TIMEOUT = 5000.milliseconds
+
+/**
+ * Default timeout for Maven search operations.
+ */
+private val MAVEN_SEARCH_REQUEST_TIMEOUT = 10_000.milliseconds
+
+/**
+ * Timeout for executor shutdown; allows running tasks to respond to interrupt.
+ */
+private const val SHUTDOWN_TIMEOUT_MS = 5000L
+
+/**
+ * Maximum number of concurrent version fetch requests.
+ */
+private val maxConcurrentVersionFetches = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+
+/**
+ * Represents a Maven artifact with all its available versions pre-fetched.
+ *
+ * @property groupId The Maven group ID (e.g., "io.gitlab.arturbosch.detekt").
+ * @property artifactId The Maven artifact ID (e.g., "detekt-formatting").
+ * @property versions All available versions, sorted in descending order (latest first).
+ */
+data class MavenArtifact(val groupId: String, val artifactId: String, val versions: List<String>) {
+    /**
+     * The latest (highest) available version, or `null` if no versions are available.
+     */
+    val latestVersion: String?
+        get() = versions.firstOrNull()
+
+    /**
+     * Represents a parsed Maven GAV coordinate.
+     */
+    data class MavenGav(val groupId: String, val artifactId: String, val version: String?)
+}
+
+fun interface ArtifactSearchBackend {
+    fun search(project: Project, query: String, onResults: (List<RepositoryArtifactDescription>) -> Unit)
+}
+
+fun interface VersionsFetcher {
+    fun fetch(artifacts: List<RepositoryArtifactDescription>): List<MavenArtifact>
+}
+
+/**
+ * Fetches Maven artifacts from configured repositories.
+ *
+ * This class provides a simple API to search for Maven artifacts. It handles all the complexity of:
+ * - Searching repositories via [JarRepositoryManager]
+ * - Deduplicating results by groupId:artifactId (keeping the highest version)
+ * - Pre-fetching all available versions for each artifact
+ * - Sorting versions in descending order (latest first)
+ *
+ * Usage:
+ * ```kotlin
+ * val fetcher = MavenArtifactFetcher(project)
+ * fetcher.searchArtifacts("detekt") { artifacts ->
+ *     // artifacts is List<MavenArtifact> with versions pre-fetched
+ *     artifacts.forEach { println("${it.groupId}:${it.artifactId} - ${it.latestVersion}") }
+ * }
+ * ```
+ *
+ * @param project The IntelliJ project context used for Maven repository operations.
+ * @param requestTimeout Timeout for version fetching. Defaults to [MAVEN_FETCH_REQUEST_TIMEOUT].
+ * @param searchTimeout Timeout for Maven search operations. Defaults to [MAVEN_SEARCH_REQUEST_TIMEOUT].
+ */
+class MavenArtifactFetcher(
+    private val project: Project,
+    private val requestTimeout: Duration = MAVEN_FETCH_REQUEST_TIMEOUT,
+    private val searchTimeout: Duration = MAVEN_SEARCH_REQUEST_TIMEOUT,
+    internal val searchBackend: ArtifactSearchBackend = JarRepositoryArtifactSearchBackend,
+    versionsFetcher: VersionsFetcher? = null,
+    internal val scheduler: ScheduledExecutorService = AppExecutorUtil.getAppScheduledExecutorService(),
+) {
+    private val logger = thisLogger()
+    private val versionsFetcher: VersionsFetcher =
+        versionsFetcher ?: VersionsFetcher { artifacts -> fetchVersionsInParallel(artifacts) }
+
+    /**
+     * Searches for Maven artifacts matching the given query.
+     *
+     * This method searches Maven Central and other configured repositories, deduplicates results, and pre-fetches all
+     * available versions for each artifact in parallel (up to [maxConcurrentVersionFetches] at a time). The callback
+     * is invoked with the complete results.
+     *
+     * The search and version fetching happen asynchronously. The callback is invoked on a background thread - callers
+     * should handle EDT switching if needed for UI updates.
+     *
+     * @param query The search query (e.g., "detekt" or "io.gitlab.arturbosch").
+     * @param onResults Callback invoked with the list of artifacts, each with pre-fetched versions sorted in descending
+     *   order.
+     */
+    fun searchArtifacts(query: String, onResults: (List<MavenArtifact>) -> Unit) {
+        logger.debug("Searching for artifacts with query: $query")
+
+        val completed = AtomicBoolean(false)
+        val timeoutFuture =
+            scheduler.schedule(
+                {
+                    if (completed.compareAndSet(false, true)) {
+                        logger.warn("Maven search timed out after ${searchTimeout.inWholeMilliseconds}ms for $query")
+                        onResults(emptyList())
+                    }
+                },
+                searchTimeout.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS,
+            )
+
+        try {
+            searchBackend.search(project, query) { artifacts ->
+                if (!completed.compareAndSet(false, true)) return@search
+                timeoutFuture.cancel(false)
+
+                logger.debug("Search backend returned ${artifacts.size} results for query: $query")
+                val deduplicated = deduplicateByVersion(artifacts)
+
+                fetchVersionsAsync(deduplicated, query, onResults)
+            }
+        } catch (e: IllegalStateException) {
+            if (completed.compareAndSet(false, true)) {
+                timeoutFuture.cancel(false)
+                logger.warn("Maven search failed for query: $query", e)
+                onResults(emptyList())
+            }
+        } catch (e: IllegalArgumentException) {
+            if (completed.compareAndSet(false, true)) {
+                timeoutFuture.cancel(false)
+                logger.warn("Maven search failed for query: $query", e)
+                onResults(emptyList())
+            }
+        }
+    }
+
+    private fun fetchVersionsAsync(
+        deduplicated: List<RepositoryArtifactDescription>,
+        query: String,
+        onResults: (List<MavenArtifact>) -> Unit,
+    ) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            logger.debug("Fetching versions for ${deduplicated.size} artifacts in parallel")
+
+            val mavenArtifacts =
+                try {
+                    versionsFetcher.fetch(deduplicated)
+                } catch (e: TimeoutException) {
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                } catch (e: ExecutionException) {
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                } catch (e: CancellationException) {
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                } catch (e: IllegalStateException) {
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                } catch (e: IllegalArgumentException) {
+                    logger.warn("Failed to fetch versions for query: $query. Falling back to latest only.", e)
+                    fallbackArtifacts(deduplicated)
+                }
+
+            val sortedResults = mavenArtifacts.sortedWith(compareBy({ it.groupId }, { it.artifactId }))
+            logger.debug("Returning ${sortedResults.size} artifacts with pre-fetched versions")
+            onResults(sortedResults)
+        }
+    }
+
+    private fun fallbackArtifacts(artifacts: List<RepositoryArtifactDescription>): List<MavenArtifact> =
+        artifacts.map {
+            MavenArtifact(it.groupId, it.artifactId, listOf(it.version))
+        }
+
+    private fun fallbackArtifact(artifact: RepositoryArtifactDescription): MavenArtifact =
+        MavenArtifact(artifact.groupId, artifact.artifactId, listOf(artifact.version))
+
+    private fun fetchVersionsInParallel(artifacts: List<RepositoryArtifactDescription>): List<MavenArtifact> {
+        if (artifacts.isEmpty()) return emptyList()
+
+        val callables =
+            artifacts.map { artifact ->
+                Callable {
+                    val versions = fetchVersions(artifact.groupId, artifact.artifactId)
+                    MavenArtifact(
+                        groupId = artifact.groupId,
+                        artifactId = artifact.artifactId,
+                        versions = versions.ifEmpty { listOf(artifact.version) },
+                    )
+                }
+            }
+
+        return runCallablesWithTimeoutAndShutdownUsingFallback(
+            callables = callables,
+            timeoutMs = requestTimeout.inWholeMilliseconds,
+            shutdownTimeoutMs = SHUTDOWN_TIMEOUT_MS,
+            onTimeout = { logger.warn("Version fetch timed out after ${requestTimeout.inWholeMilliseconds}ms", it) },
+            onFailure = { logger.warn("Failed to fetch versions", it) },
+            onShutdownInterrupted = { logger.debug("Interrupted while waiting for executor shutdown", it) },
+            fallback = { index -> fallbackArtifact(artifacts[index]) },
+        )
+    }
+
+    private fun fetchVersions(groupId: String, artifactId: String): List<String> {
+        val key = createArtifactKey(groupId, artifactId)
+        logger.debug("Fetching versions for $key")
+
+        val props = RepositoryLibraryProperties(key, "jar", true)
+        val libraryDescription = RepositoryLibraryDescription.findDescription(props)
+
+        @Suppress("TooGenericExceptionCaught") // IJPL throws generic exceptions :(
+        return try {
+            val timeout = requestTimeout.inWholeMilliseconds.toInt()
+            val versions =
+                retryOnceOnTimeout {
+                    JarRepositoryManager.getAvailableVersions(project, libraryDescription).blockingGet(timeout)
+                }
+
+            if (versions != null) {
+                logger.debug("Fetched ${versions.size} versions for $key")
+                sortVersionsDescending(versions)
+            } else {
+                logger.debug("No versions found for $key")
+                emptyList()
+            }
+        } catch (e: TimeoutException) {
+            logger.warn("Failed to fetch versions for $key after retry", e)
+            emptyList()
+        } catch (e: Exception) {
+            logger.warn("Failed to fetch versions for $key", e)
+            emptyList()
+        }
+    }
+
+    companion object {
+        @VisibleForTesting
+        internal fun <T> retryOnceOnTimeout(action: () -> T): T =
+            try {
+                action()
+            } catch (_: TimeoutException) {
+                action()
+            }
+
+        /**
+         * Runs callables on a fixed thread pool with per-future timeout and ensures the executor is shut down via
+         * [java.util.concurrent.ExecutorService.shutdownNow] in all cases (success, timeout, or exception). Visible for
+         * testing timeout and shutdown behavior.
+         */
+        @VisibleForTesting
+        internal fun <T> runCallablesWithTimeoutAndShutdown(
+            callables: List<Callable<T>>,
+            timeoutMs: Long,
+            shutdownTimeoutMs: Long,
+            onTimeout: (TimeoutException) -> Unit = {},
+            onShutdownInterrupted: (InterruptedException) -> Unit = {},
+        ): List<T> {
+            if (callables.isEmpty()) return emptyList()
+
+            val poolSize = callables.size.coerceAtMost(maxConcurrentVersionFetches)
+            val executor = Executors.newFixedThreadPool(poolSize)
+            try {
+                val futures = callables.map { executor.submit(it) }
+                return futures.map { future ->
+                    try {
+                        future.get(timeoutMs, TimeUnit.MILLISECONDS)
+                    } catch (e: TimeoutException) {
+                        future.cancel(true)
+                        onTimeout(e)
+                        throw e
+                    } catch (e: InterruptedException) {
+                        future.cancel(true)
+                        Thread.currentThread().interrupt()
+                        throw e
+                    }
+                }
+            } finally {
+                executor.shutdownNow()
+                try {
+                    executor.awaitTermination(shutdownTimeoutMs, TimeUnit.MILLISECONDS)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    onShutdownInterrupted(e)
+                }
+            }
+        }
+
+        /**
+         * Runs callables on a fixed thread pool with per-future timeout and ensures the executor is shut down via
+         * [java.util.concurrent.ExecutorService.shutdownNow]. Failures or timeouts return a fallback value for that
+         * callable instead of failing the whole batch.
+         */
+        @Suppress("LongParameterList") // Unavoidable within reason
+        @VisibleForTesting
+        internal fun <T> runCallablesWithTimeoutAndShutdownUsingFallback(
+            callables: List<Callable<T>>,
+            timeoutMs: Long,
+            shutdownTimeoutMs: Long,
+            onTimeout: (TimeoutException) -> Unit = {},
+            onFailure: (Exception) -> Unit = {},
+            onShutdownInterrupted: (InterruptedException) -> Unit = {},
+            fallback: (Int) -> T,
+        ): List<T> {
+            if (callables.isEmpty()) return emptyList()
+
+            val poolSize = callables.size.coerceAtMost(maxConcurrentVersionFetches)
+            val executor = Executors.newFixedThreadPool(poolSize)
+            try {
+                val futures = callables.map { executor.submit(it) }
+                return futures.mapIndexed { index, future ->
+                    try {
+                        future.get(timeoutMs, TimeUnit.MILLISECONDS)
+                    } catch (e: TimeoutException) {
+                        future.cancel(true)
+                        onTimeout(e)
+                        fallback(index)
+                    } catch (e: ExecutionException) {
+                        onFailure(e)
+                        fallback(index)
+                    } catch (e: CancellationException) {
+                        onFailure(e)
+                        fallback(index)
+                    } catch (e: InterruptedException) {
+                        future.cancel(true)
+                        Thread.currentThread().interrupt()
+                        onFailure(e)
+                        fallback(index)
+                    }
+                }
+            } finally {
+                executor.shutdownNow()
+                try {
+                    executor.awaitTermination(shutdownTimeoutMs, TimeUnit.MILLISECONDS)
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    onShutdownInterrupted(e)
+                }
+            }
+        }
+
+        /**
+         * Creates a key for artifact identification.
+         *
+         * @return A key in the format "groupId:artifactId".
+         */
+        @JvmStatic
+        fun createArtifactKey(groupId: String, artifactId: String): String = "$groupId:$artifactId"
+
+        /**
+         * Sorts versions in descending order (latest first).
+         *
+         * Uses [VersionComparatorUtil] for semantic version comparison.
+         */
+        @JvmStatic
+        fun sortVersionsDescending(versions: Collection<String>): List<String> =
+            versions.sortedWith(VersionComparatorUtil.COMPARATOR.reversed())
+
+        /**
+         * Deduplicates artifacts by groupId:artifactId, keeping the highest version.
+         *
+         * @param artifacts The artifacts to deduplicate.
+         * @return A list of unique artifacts, each with the highest available version.
+         * @see VersionComparatorUtil
+         */
+        @JvmStatic
+        fun deduplicateByVersion(
+            artifacts: Collection<RepositoryArtifactDescription>,
+        ): List<RepositoryArtifactDescription> {
+            val bestResults = mutableMapOf<String, RepositoryArtifactDescription>()
+            artifacts.forEach { artifact ->
+                val key = createArtifactKey(artifact.groupId, artifact.artifactId)
+                val current = bestResults[key]
+                if (current == null || VersionComparatorUtil.compare(artifact.version, current.version) > 0) {
+                    bestResults[key] = artifact
+                }
+            }
+            return bestResults.values.toList()
+        }
+
+        /**
+         * Parses a Maven GAV coordinate from a string.
+         *
+         * Supports:
+         * - groupId:artifactId:version
+         * - groupId:artifactId:packaging:version
+         *
+         * @return The parsed [MavenArtifact.MavenGav], or `null` if the format is invalid.
+         */
+        @JvmStatic
+        fun parseGav(query: String): MavenArtifact.MavenGav? {
+            val parts = query.split(":").map { it.trim() }
+            if (parts.size < 2 || parts.any { it.isEmpty() }) return null
+
+            val groupId = parts[0]
+            val artifactId = parts[1]
+            val version = if (parts.size >= MIN_COORDINATES_PARTS) parts.last() else null
+
+            return MavenArtifact.MavenGav(groupId, artifactId, version)
+        }
+    }
+}
+
+private object JarRepositoryArtifactSearchBackend : ArtifactSearchBackend {
+    override fun search(project: Project, query: String, onResults: (List<RepositoryArtifactDescription>) -> Unit) {
+        JarRepositoryManager.searchArtifacts(project, query) { results ->
+            onResults(results.map { it.first })
+        }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenSearchDialog.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenSearchDialog.kt
@@ -1,0 +1,447 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.TableSpeedSearch
+import com.intellij.ui.components.ActionLink
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.AsyncProcessIcon
+import io.gitlab.arturbosch.detekt.idea.DetektBundle
+import io.gitlab.arturbosch.detekt.idea.util.DetektPlugin
+import io.gitlab.arturbosch.detekt.idea.util.MavenDependencyResolver
+import java.awt.Dimension
+import java.awt.datatransfer.StringSelection
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
+import javax.swing.KeyStroke
+import javax.swing.ListSelectionModel
+import javax.swing.event.DocumentEvent
+import javax.swing.table.DefaultTableModel
+
+private const val SEARCH_DIALOG_WIDTH = 600
+private const val SEARCH_DIALOG_HEIGHT = 450
+private const val VERSION_COMBO_WIDTH = 200
+
+/**
+ * Dialog for searching Maven artifacts. It allows users to search for artifacts, select a version, and customize
+ * transitive dependencies.
+ */
+@Suppress("TooManyFunctions") // Unavoidable due to UI DSL
+class MavenSearchDialog(
+    private val project: Project,
+    private val artifactFetcher: MavenArtifactFetcher = MavenArtifactFetcher(project),
+    private val dependencyResolver: MavenDependencyResolver = MavenDependencyResolver(project),
+) : DialogWrapper(project) {
+
+    private val logger = thisLogger()
+    private val application = ApplicationManager.getApplication()
+
+    private var pendingGav: MavenArtifact.MavenGav? = null
+
+    private lateinit var searchField: JBTextField
+    private lateinit var searchButton: JButton
+    private lateinit var resultTable: JBTable
+    private lateinit var versionComboBox: ComboBox<String>
+
+    // Transitive Deps UI
+    private lateinit var transitiveDepsLabel: JLabel
+    private lateinit var customizeLink: ActionLink
+    private lateinit var transitiveProcessIcon: AsyncProcessIcon
+
+    private val resultModel =
+        object :
+            DefaultTableModel(
+                arrayOf(
+                    DetektBundle.message("detekt.configuration.mavenSearch.tableHeader.group"),
+                    DetektBundle.message("detekt.configuration.mavenSearch.tableHeader.artifact"),
+                    DetektBundle.message("detekt.configuration.mavenSearch.tableHeader.latestVersion"),
+                ),
+                0,
+            ) {
+            override fun isCellEditable(row: Int, column: Int): Boolean = false
+        }
+
+    private var searchResults: List<MavenArtifact> = emptyList()
+    private var selectedArtifact: MavenArtifact? = null
+    private var isSearching = false
+
+    // State for the selected artifact
+    private var isResolving: Boolean = false // simple flag to track if we are resolving
+    private var resolvedRoot: MavenDependencyResolver.ResolvedNode? = null
+    private var currentExclusions: MutableSet<String> = mutableSetOf()
+
+    init {
+        title = DetektBundle.message("detekt.configuration.mavenSearch.title")
+        init()
+        isOKActionEnabled = false
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = panel {
+            searchBarRow()
+            marketplaceRow()
+            resultsRow()
+            versionsRow()
+            transitiveDependenciesRow()
+        }
+
+        panel.preferredSize = Dimension(SEARCH_DIALOG_WIDTH, SEARCH_DIALOG_HEIGHT)
+
+        return panel
+    }
+
+    private fun Panel.marketplaceRow() {
+        row {
+            comment(DetektBundle.message("detekt.configuration.mavenSearch.marketplaceBlurb"))
+        }
+    }
+
+    private fun Panel.searchBarRow() {
+        row(DetektBundle.message("detekt.configuration.mavenSearch.searchLabel")) {
+            searchField = textField()
+                .align(AlignX.FILL)
+                .resizableColumn()
+                .applyToComponent { addActionListener { performSearch() } }
+                .component
+
+            searchButton = button(DetektBundle.message("detekt.configuration.mavenSearch.searchButton")) {
+                performSearch()
+            }.applyToComponent {
+                isEnabled = false
+                registerKeyboardAction(
+                    { performSearch() },
+                    KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                    JComponent.WHEN_FOCUSED,
+                )
+            }.component
+
+            searchField.document.addDocumentListener(
+                object : DocumentAdapter() {
+                    override fun textChanged(e: DocumentEvent) {
+                        updateSearchButtonState()
+                    }
+                }
+            )
+        }
+    }
+
+    private fun Panel.resultsRow() {
+        resultTable = JBTable(resultModel)
+        resultTable.selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        resultTable.selectionModel.addListSelectionListener { e ->
+            if (!e.valueIsAdjusting) {
+                onArtifactSelected()
+            }
+        }
+
+        val mouseAdapter =
+            object : MouseAdapter() {
+                override fun mousePressed(e: MouseEvent) = showPopupMenu(e)
+
+                override fun mouseReleased(e: MouseEvent) = showPopupMenu(e)
+
+                private fun showPopupMenu(e: MouseEvent) {
+                    if (e.isPopupTrigger) {
+                        val row = resultTable.rowAtPoint(e.point)
+                        if (row != -1) {
+                            resultTable.setRowSelectionInterval(row, row)
+                            createContextMenu(row).show(e.component, e.x, e.y)
+                        }
+                    }
+                }
+            }
+        resultTable.addMouseListener(mouseAdapter)
+
+        TableSpeedSearch.installOn(resultTable)
+
+        row {
+            // Wrap the table in a scroll pane to prevent the table from growing too large
+            cell(JBScrollPane(resultTable)).align(AlignX.FILL).align(AlignY.FILL)
+        }.resizableRow()
+    }
+
+    private fun Panel.versionsRow() {
+        row(DetektBundle.message("detekt.configuration.mavenSearch.versionLabel")) {
+            versionComboBox = comboBox(DefaultComboBoxModel<String>())
+                .applyToComponent {
+                    isEnabled = false
+                    preferredSize = Dimension(JBUIScale.scale(VERSION_COMBO_WIDTH), preferredSize.height)
+                    addActionListener {
+                        // re-resolve on version change
+                        if (isEnabled) resolveDependencies()
+                    }
+                }.component
+        }
+    }
+
+    private fun Panel.transitiveDependenciesRow() {
+        row {
+            transitiveProcessIcon = cell(AsyncProcessIcon("TransitiveResolution"))
+                .applyToComponent { isVisible = false }
+                .component
+
+            transitiveDepsLabel = label("").component
+
+            customizeLink = link(DetektBundle.message("detekt.configuration.mavenSearch.customize")) {
+                openCustomizeDialog()
+            }.applyToComponent { isVisible = false }
+                .component
+        }
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent = searchField
+
+    /** Returns the selected artifact as a DetektPlugin object. */
+    fun getResult(): DetektPlugin? {
+        val artifact = selectedArtifact
+        val version = versionComboBox.selectedItem as? String
+        if (artifact == null || version == null) return null
+
+        val coordinate = "${artifact.groupId}:${artifact.artifactId}:$version"
+        return DetektPlugin(coordinate, currentExclusions)
+    }
+
+    private fun updateSearchButtonState() {
+        searchButton.isEnabled = !isSearching && searchField.text.isNotBlank()
+    }
+
+    private fun performSearch() {
+        val query = searchField.text.trim()
+        if (query.isEmpty()) return
+
+        logger.debug("Performing Maven search for: $query")
+
+        val gav = MavenArtifactFetcher.parseGav(query)
+        if (gav != null) {
+            pendingGav = gav
+            val searchQuery = gav.artifactId
+            logger.debug(
+                "Detected GAV coordinate. Searching for artifactId: $searchQuery (target version: ${gav.version})"
+            )
+            startSearchUI()
+            artifactFetcher.searchArtifacts(searchQuery) { results ->
+                application.invokeLater({ showResults(results) }, ModalityState.any())
+            }
+        } else {
+            pendingGav = null
+            startSearchUI()
+            artifactFetcher.searchArtifacts(query) { results ->
+                application.invokeLater({ showResults(results) }, ModalityState.any())
+            }
+        }
+    }
+
+    private fun startSearchUI() {
+        resultModel.rowCount = 0
+        searchResults = emptyList()
+        selectedArtifact = null
+        versionComboBox.removeAllItems()
+        versionComboBox.isEnabled = false
+        isSearching = true
+        updateSearchButtonState()
+        resultTable.setPaintBusy(true)
+        resultTable.emptyText.text = com.intellij.util.ui.StatusText.getDefaultEmptyText()
+
+        // Reset transitive area
+        resetTransitiveUI()
+    }
+
+    private fun resetTransitiveUI() {
+        isOKActionEnabled = false
+        transitiveDepsLabel.text = ""
+        customizeLink.isVisible = false
+        resolvedRoot = null
+        currentExclusions.clear()
+        isResolving = false
+        transitiveProcessIcon.isVisible = false
+        transitiveProcessIcon.suspend()
+    }
+
+    private fun showResults(artifacts: List<MavenArtifact>) {
+        logger.debug("Showing ${artifacts.size} results")
+
+        val target = pendingGav
+        val filteredArtifacts =
+            if (target != null) {
+                artifacts.filter { it.groupId == target.groupId && it.artifactId == target.artifactId }
+            } else {
+                artifacts
+            }
+
+        searchResults = filteredArtifacts
+        resultModel.rowCount = 0
+
+        for (artifact in filteredArtifacts) {
+            resultModel.addRow(arrayOf(artifact.groupId, artifact.artifactId, artifact.latestVersion ?: ""))
+        }
+
+        if (filteredArtifacts.isEmpty()) {
+            resultTable.emptyText.text = DetektBundle.message("detekt.configuration.mavenSearch.noResults")
+        }
+
+        isSearching = false
+        updateSearchButtonState()
+        resultTable.setPaintBusy(false)
+
+        if (target != null && filteredArtifacts.isNotEmpty()) {
+            // Auto-select the first (and likely only) matching result
+            logger.debug("Auto-selecting artifact row for GAV: ${target.groupId}:${target.artifactId}")
+            resultTable.setRowSelectionInterval(0, 0)
+            onArtifactSelected() // Explicitly trigger to ensure versions are shown
+        }
+    }
+
+    private fun onArtifactSelected() {
+        val row = resultTable.selectedRow
+        if (row >= 0 && row < searchResults.size) {
+            val artifact = searchResults[row]
+            selectedArtifact = artifact
+            logger.debug("Selected artifact: ${artifact.groupId}:${artifact.artifactId}")
+
+            val targetVersion =
+                pendingGav?.let {
+                    if (it.groupId == artifact.groupId && it.artifactId == artifact.artifactId) it.version else null
+                }
+            showVersions(artifact.versions, targetVersion)
+
+            if (targetVersion != null) {
+                pendingGav = null
+            }
+
+            // showVersions will trigger action listener which calls resolveDependencies
+            // But we need to make sure we call it if the list is populated and index 0 selected
+            // automatically
+            if (versionComboBox.itemCount > 0) {
+                resolveDependencies()
+            }
+        } else {
+            selectedArtifact = null
+            versionComboBox.removeAllItems()
+            versionComboBox.isEnabled = false
+            resetTransitiveUI()
+        }
+    }
+
+    private fun showVersions(versions: List<String>, targetVersion: String? = null) {
+        versionComboBox.removeAllItems()
+        versions.forEach { versionComboBox.addItem(it) }
+
+        if (targetVersion != null && versions.contains(targetVersion)) {
+            logger.debug("Auto-selecting target version: $targetVersion")
+            versionComboBox.selectedItem = targetVersion
+        } else if (versions.isNotEmpty()) {
+            versionComboBox.selectedIndex = 0
+        }
+        versionComboBox.isEnabled = versions.isNotEmpty()
+    }
+
+    private fun resolveDependencies() {
+        val artifact = selectedArtifact ?: return
+        val version = versionComboBox.selectedItem as? String ?: return
+
+        logger.debug("Resolving dependencies for ${artifact.groupId}:${artifact.artifactId}:$version")
+
+        // UI State: Loading
+        isOKActionEnabled = false
+        isResolving = true
+        transitiveDepsLabel.text = DetektBundle.message("detekt.configuration.mavenSearch.resolvingTransitive", version)
+        customizeLink.isVisible = false
+        transitiveProcessIcon.isVisible = true
+        transitiveProcessIcon.resume()
+
+        val coordinate = "${artifact.groupId}:${artifact.artifactId}:$version"
+
+        application.executeOnPooledThread {
+            @Suppress("TooGenericExceptionCaught") // IJPL throws generic exceptions :(
+            try {
+                val root = dependencyResolver.resolve(coordinate)
+                application.invokeLater({ onDependenciesResolved(root) }, ModalityState.any())
+            } catch (e: Exception) {
+                logger.error("Failed to resolve dependencies for $coordinate", e)
+                application.invokeLater({ onDependenciesResolved(null) }, ModalityState.any())
+            }
+        }
+    }
+
+    private fun onDependenciesResolved(root: MavenDependencyResolver.ResolvedNode?) {
+        if (!isResolving) return
+
+        isResolving = false
+        transitiveProcessIcon.isVisible = false
+        transitiveProcessIcon.suspend()
+
+        resolvedRoot = root
+        currentExclusions.clear()
+
+        if (root != null) {
+            logger.debug("Successfully resolved dependencies for ${root.coordinate}")
+            isOKActionEnabled = true
+            updateTransitiveLabel()
+            customizeLink.isVisible = true
+        } else {
+            logger.warn("Failed to resolve dependencies")
+            transitiveDepsLabel.text = DetektBundle.message("detekt.configuration.mavenSearch.failedToResolve")
+            isOKActionEnabled = false
+            customizeLink.isVisible = false
+        }
+    }
+
+    private fun updateTransitiveLabel() {
+        val root = resolvedRoot ?: return
+
+        val allNodes = flatten(root)
+        val validDeps =
+            allNodes.filter {
+                it.coordinate != root.coordinate && !it.isProvided && it.coordinate !in currentExclusions
+            }
+
+        val count = validDeps.distinctBy { it.coordinate }.size
+        transitiveDepsLabel.text = DetektBundle.message("detekt.configuration.mavenSearch.includesTransitive", count)
+    }
+
+    private fun flatten(node: MavenDependencyResolver.ResolvedNode): List<MavenDependencyResolver.ResolvedNode> =
+        listOf(node) + node.children.flatMap { flatten(it) }
+
+    private fun openCustomizeDialog() {
+        val root = resolvedRoot ?: return
+        val editor = DependencyExclusionEditor(root, contentPane)
+        val newExclusions = editor.selectExcludedDependencies(currentExclusions)
+        if (newExclusions != null) {
+            currentExclusions.clear()
+            currentExclusions.addAll(newExclusions)
+            updateTransitiveLabel()
+        }
+    }
+
+    private fun createContextMenu(row: Int): JPopupMenu {
+        val popup = JPopupMenu()
+        val copyItem = JMenuItem(DetektBundle.message("detekt.configuration.mavenSearch.copyCoordinates"))
+        copyItem.addActionListener {
+            val artifact = searchResults[row]
+            val coords = "${artifact.groupId}:${artifact.artifactId}"
+            CopyPasteManager.getInstance().setContents(StringSelection(coords))
+        }
+        popup.add(copyItem)
+        return popup
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/PluginsListPanel.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/PluginsListPanel.kt
@@ -1,0 +1,139 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import com.intellij.CommonBundle
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBList
+import icons.MavenIcons
+import io.gitlab.arturbosch.detekt.idea.DetektBundle
+import io.gitlab.arturbosch.detekt.idea.util.DetektPlugin
+import java.awt.GraphicsEnvironment
+import javax.swing.DefaultListModel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+
+internal sealed interface PluginSpec {
+    data class Jar(val file: VirtualFile) : PluginSpec
+
+    data class Maven(val plug: DetektPlugin) : PluginSpec
+}
+
+internal class PluginsListPanel(private val listModel: PluginListModel, private val project: Project) {
+
+    private val list =
+        JBList(listModel).apply {
+            if (!GraphicsEnvironment.isHeadless()) {
+                dragEnabled = true
+            }
+            selectionModel.selectionMode = ListSelectionModel.MULTIPLE_INTERVAL_SELECTION
+            cellRenderer = Renderer()
+        }
+
+    fun decorated(): JPanel =
+        ToolbarDecorator.createDecorator(list)
+            .setAddAction { onAddJarClick() }
+            .setAddActionName(DetektBundle.message("detekt.configuration.plugins.dialog.title.jar"))
+            .addExtraAction(
+                object : DumbAwareAction(
+                    DetektBundle.message("detekt.configuration.mavenSearch.title"),
+                    null,
+                    MavenIcons.ToolWindowMaven,
+                ) {
+                    override fun actionPerformed(e: AnActionEvent) {
+                        onAddMavenClick()
+                    }
+                }
+            )
+            .setRemoveAction { onRemoveClick() }
+            .setButtonComparator(
+                DetektBundle.message("detekt.configuration.plugins.dialog.title.jar"),
+                DetektBundle.message("detekt.configuration.mavenSearch.title"),
+                CommonBundle.message("button.remove"),
+            )
+            .createPanel()
+
+    private fun onRemoveClick() {
+        listModel.removeAt(list.selectedIndices.toList())
+    }
+
+    private fun onAddJarClick() {
+        val descriptor = FileChooserDescriptorUtil.createJarsChooserDescriptor()
+        descriptor.title = DetektBundle.message("detekt.configuration.plugins.dialog.title.jar")
+        descriptor.description = DetektBundle.message("detekt.configuration.plugins.dialog.description.jar")
+
+        val files = FileChooser.chooseFiles(descriptor, list, project, null)
+        for (file in files) {
+            val spec = PluginSpec.Jar(file)
+            if (file != null && !listModel.items.contains(spec)) {
+                listModel += spec
+            }
+        }
+    }
+
+    private fun onAddMavenClick() {
+        val dialog = MavenSearchDialog(project)
+        if (dialog.showAndGet()) {
+            val result = dialog.getResult()
+            if (result != null) {
+                val spec = PluginSpec.Maven(result)
+                if (!listModel.items.contains(spec)) {
+                    listModel += spec
+                }
+            }
+        }
+    }
+
+    class PluginListModel(initialItems: List<PluginSpec> = emptyList()) : DefaultListModel<PluginSpec>() {
+
+        val items: List<PluginSpec>
+            get() = super.elements().toList()
+
+        init {
+            addAll(initialItems)
+        }
+
+        operator fun plusAssign(newItem: PluginSpec) {
+            addElement(newItem)
+        }
+
+        operator fun plusAssign(newItems: Collection<PluginSpec>) {
+            addAll(newItems)
+        }
+
+        fun removeAt(indices: Collection<Int>) {
+            if (indices.isEmpty()) return
+            indices.sortedDescending().forEach { indexToRemove -> remove(indexToRemove) }
+        }
+    }
+
+    private class Renderer : ColoredListCellRenderer<PluginSpec>() {
+        override fun customizeCellRenderer(
+            list: JList<out PluginSpec>,
+            value: PluginSpec,
+            index: Int,
+            selected: Boolean,
+            hasFocus: Boolean,
+        ) {
+            when (value) {
+                is PluginSpec.Jar -> {
+                    icon = value.file.fileType.icon
+                    append(value.file.name, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                    append(" (${value.file.parent.path})", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                }
+
+                is PluginSpec.Maven -> {
+                    icon = AllIcons.Nodes.PpLib
+                    append(value.plug.coordinate, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/CoordToRelativePath.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/CoordToRelativePath.kt
@@ -1,0 +1,26 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import org.jetbrains.annotations.VisibleForTesting
+
+internal const val MIN_COORDINATES_PARTS = 3
+
+/**
+ * Converts Maven coordinates and a filename into a relative path structure.
+ *
+ * For example, given coordinates `io.gitlab.arturbosch.detekt:detekt-cli:1.23.0` and filename `detekt-cli-1.23.0.jar`,
+ * it will return `io/gitlab/arturbosch/detekt/detekt-cli/1.23.0/detekt-cli-1.23.0.jar`.
+ *
+ * @param coord Maven coordinates in the format `groupId:artifactId:version`.
+ * @param fileName The name of the file to append to the path.
+ * @return A relative path string, or "unknown/$fileName" if the coordinates are invalid.
+ */
+@VisibleForTesting
+internal fun coordToRelativePath(coord: String, fileName: String): String {
+    val parts = coord.split(":")
+    if (parts.size >= MIN_COORDINATES_PARTS) {
+        // group/artifact/version/fileName
+        val groupPath = parts[0].replace('.', '/')
+        return "$groupPath/${parts[1]}/${parts[2]}/$fileName"
+    }
+    return "unknown/$fileName"
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/DetektPlugin.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/DetektPlugin.kt
@@ -1,0 +1,9 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+/**
+ * Represents a Detekt plugin and its configuration.
+ *
+ * @property coordinate The Maven coordinate (groupId:artifactId:version) of the plugin.
+ * @property exclusions A set of coordinates or groupId:artifactId strings to exclude from the dependency tree.
+ */
+data class DetektPlugin(var coordinate: String = "", var exclusions: MutableSet<String> = mutableSetOf())

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ExtractCoordinate.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ExtractCoordinate.kt
@@ -1,0 +1,40 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties
+
+private const val MIN_PATH_PARTS = 4
+
+/**
+ * Extracts Maven coordinates from a [com.intellij.openapi.vfs.VirtualFile].
+ *
+ * It attempts to extract coordinates from the file path if it's located within a Maven repository structure
+ * (e.g., `.../repository/group/id/artifactId/version/artifact-version.jar`).
+ *
+ * @param file The [VirtualFile] representing the artifact.
+ * @param mainProps Default properties to use if `isMain` is true.
+ * @param isMain If true, the coordinates are directly taken from [mainProps].
+ * @return Maven coordinates in the format `groupId:artifactId:version`, or a best-effort "unknown" string if extraction
+ *   fails.
+ */
+@Suppress("ReturnCount") // No idea how to trim it further
+internal fun extractCoordinate(file: VirtualFile, mainProps: RepositoryLibraryProperties, isMain: Boolean): String {
+    if (isMain) return "${mainProps.groupId}:${mainProps.artifactId}:${mainProps.version}"
+
+    val path = file.path
+    val repoMarker = "/repository/"
+    val index = path.lastIndexOf(repoMarker)
+    if (index != -1) {
+        val relativePath = path.substring(index + repoMarker.length)
+        val parts = relativePath.split('/')
+        if (parts.size >= MIN_PATH_PARTS) {
+            // .../group/part/artifactId/version/artifact-version.jar
+            val versionIndex = parts.size - 2
+            val version = parts[versionIndex]
+            val artifactId = parts[versionIndex - 1]
+            val groupId = parts.subList(0, versionIndex - 1).joinToString(".")
+            return "$groupId:$artifactId:$version"
+        }
+    }
+    return "unknown:${file.nameWithoutExtension}:unknown"
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolver.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolver.kt
@@ -1,0 +1,167 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import org.jetbrains.idea.maven.aether.ArtifactDependencyNode
+import java.io.File
+
+private const val GAV_COORDINATES_PARTS_COUNT = 3
+
+class MavenDependencyResolver(
+    private val project: Project,
+    private val treeResolver: MavenTreeResolver = MavenTreeResolver.Default,
+) {
+    private val logger = thisLogger()
+
+    /**
+     * Represents a resolved dependency node in the Maven dependency tree.
+     *
+     * @property groupId The group ID of the dependency.
+     * @property artifactId The artifact ID of the dependency.
+     * @property version The version of the dependency.
+     * @property coordinate The full GAV coordinate string (groupId:artifactId:version).
+     * @property isProvided Whether this dependency is force-excluded by the platform (e.g., standard libraries).
+     * @property isRejected Whether this dependency was rejected by the resolver (e.g., due to conflicts).
+     * @property children The list of transitive dependencies.
+     * @property file The resolved artifact file on disk, if available.
+     */
+    data class ResolvedNode(
+        val groupId: String,
+        val artifactId: String,
+        val version: String,
+        val coordinate: String,
+        val isProvided: Boolean,
+        val isRejected: Boolean,
+        val children: List<ResolvedNode>,
+        val file: File? = null,
+    )
+
+    /**
+     * Resolves the dependency tree for the given [coordinate].
+     *
+     * This method fetches the full transitive dependency tree and maps it to a tree of [ResolvedNode]s, identifying
+     * force-excluded and rejected dependencies along the way.
+     *
+     * @param coordinate The GAV coordinate to resolve (groupId:artifactId:version).
+     * @return The root [ResolvedNode] of the resolved tree, or null if resolution fails.
+     */
+    @Suppress("ReturnCount") // No idea how to reduce them without making the code worse
+    fun resolve(
+        coordinate: String,
+        shouldDownload: Boolean = false,
+        exclusions: List<String> = emptyList(),
+        indicator: ProgressIndicator? = null,
+    ): ResolvedNode? {
+        logger.debug("Resolving coordinate: $coordinate (download: $shouldDownload)")
+        val parts = coordinate.split(":")
+        if (parts.size < GAV_COORDINATES_PARTS_COUNT) {
+            logger.warn("Invalid coordinate format: $coordinate")
+            return null
+        }
+
+        val groupId = parts[0]
+        val artifactId = parts[1]
+        val version = parts[2]
+
+        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
+            logger.warn("Invalid coordinate: groupId, artifactId and version must be non-empty: $coordinate")
+            return null
+        }
+
+        val (rootNode, resolvedFiles) =
+            treeResolver.resolveDependenciesTree(
+                groupId,
+                artifactId,
+                version,
+                project,
+                shouldDownload,
+                exclusions,
+                indicator,
+            )
+        if (rootNode == null) {
+            logger.warn("Could not resolve tree for $coordinate")
+            return null
+        }
+
+        val resolved = mapToResolvedNode(rootNode, resolvedFiles)
+        logger.info("Resolved $coordinate with ${flatten(resolved).size} total nodes")
+        return resolved
+    }
+
+    /**
+     * Maps an [ArtifactDependencyNode] and its resolved files to a [ResolvedNode] tree.
+     *
+     * Includes cycle detection to prevent [StackOverflowError] in case of cyclic dependencies.
+     */
+    private fun mapToResolvedNode(
+        node: ArtifactDependencyNode,
+        resolvedFiles: Map<String, File>,
+        visited: Set<String> = emptySet(),
+    ): ResolvedNode {
+        val artifact = node.artifact
+        val coord = "${artifact.groupId}:${artifact.artifactId}:${artifact.version}"
+
+        if (visited.contains(coord)) {
+            logger.warn("Cycle detected during tree mapping at $coord. Skipping children.")
+            return createLeafNode(
+                artifact.groupId,
+                artifact.artifactId,
+                artifact.version,
+                coord,
+                artifact.file ?: resolvedFiles[coord],
+                isRejected = true,
+            )
+        }
+
+        val file = artifact.file ?: resolvedFiles[coord]
+        val isProvided = ProvidedDependencies.isProvided(artifact.groupId, artifact.artifactId)
+
+        logger.debug("Mapping node: $coord (file: ${file?.name}, provided: $isProvided)")
+
+        val newVisited = visited + coord
+        return ResolvedNode(
+            groupId = artifact.groupId,
+            artifactId = artifact.artifactId,
+            version = artifact.version,
+            coordinate = coord,
+            isProvided = isProvided,
+            isRejected = node.isRejected,
+            children = node.dependencies.map { mapToResolvedNode(it, resolvedFiles, newVisited) },
+            file = file,
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun createLeafNode(
+        groupId: String,
+        artifactId: String,
+        version: String,
+        coord: String,
+        file: File?,
+        isRejected: Boolean,
+    ): ResolvedNode {
+        val isProvided = ProvidedDependencies.isProvided(groupId, artifactId)
+        return ResolvedNode(
+            groupId = groupId,
+            artifactId = artifactId,
+            version = version,
+            coordinate = coord,
+            isProvided = isProvided,
+            isRejected = isRejected,
+            children = emptyList(),
+            file = file,
+        )
+    }
+
+    /**
+     * Flattens the [ResolvedNode] tree into a list of all nodes.
+     *
+     * Includes cycle detection to prevent [StackOverflowError] in case of cyclic dependencies.
+     */
+    internal fun flatten(node: ResolvedNode, visited: Set<String> = emptySet()): List<ResolvedNode> {
+        if (visited.contains(node.coordinate)) return emptyList()
+        val newVisited = visited + node.coordinate
+        return listOf(node) + node.children.flatMap { flatten(it, newVisited) }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenTreeResolver.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenTreeResolver.kt
@@ -1,0 +1,219 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.jarRepository.JarRepositoryAuthenticationDataProvider
+import com.intellij.jarRepository.JarRepositoryManager
+import com.intellij.jarRepository.RemoteRepositoriesConfiguration
+import com.intellij.jarRepository.RemoteRepositoryDescription
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts
+import com.intellij.openapi.util.NlsContexts.ProgressText
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import org.jetbrains.idea.maven.aether.ArtifactDependencyNode
+import org.jetbrains.idea.maven.aether.ArtifactKind
+import org.jetbrains.idea.maven.aether.ArtifactRepositoryManager
+import org.jetbrains.idea.maven.aether.ProgressConsumer
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryDescription
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties
+import java.io.File
+import java.util.EnumSet
+
+/**
+ * Resolver for Maven dependency trees.
+ */
+interface MavenTreeResolver {
+    /**
+     * Resolves the dependency tree for the given Maven coordinates.
+     *
+     * @param groupId the group ID of the Maven artifact
+     * @param artifactId the artifact ID of the Maven artifact
+     * @param version the version of the Maven artifact
+     * @param project the IntelliJ project
+     * @return the root node of the resolved dependency tree, or null if resolution fails
+     */
+    @Suppress("LongParameterList") // Not worth grouping up
+    fun resolveDependenciesTree(
+        groupId: String,
+        artifactId: String,
+        version: String,
+        project: Project,
+        shouldDownload: Boolean,
+        exclusions: List<String>,
+        indicator: ProgressIndicator?,
+    ): Pair<ArtifactDependencyNode?, Map<String, File>>
+
+    companion object {
+        /**
+         * The default implementation of [MavenTreeResolver].
+         */
+        val Default: MavenTreeResolver = DefaultMavenTreeResolver
+    }
+}
+
+/**
+ * Default implementation of [MavenTreeResolver] that uses IntelliJ's [JarRepositoryManager] and
+ * [ArtifactRepositoryManager] to resolve dependencies.
+ */
+private object DefaultMavenTreeResolver : MavenTreeResolver {
+    private val logger = thisLogger()
+
+    override fun resolveDependenciesTree(
+        groupId: String,
+        artifactId: String,
+        version: String,
+        project: Project,
+        shouldDownload: Boolean,
+        exclusions: List<String>,
+        indicator: ProgressIndicator?,
+    ): Pair<ArtifactDependencyNode?, Map<String, File>> {
+        val props = RepositoryLibraryProperties(groupId, artifactId, version, true, emptyList())
+
+        logger.debug("Resolving tree for $props")
+        val description = RepositoryLibraryDescription.findDescription(props)
+        logger.debug("Resolved description: $description")
+        val (dependenciesTree, resolvedFiles) =
+            loadDependenciesTree(description, version, project, shouldDownload, exclusions, indicator)
+        logger.debug("Resolved tree:\n${dependenciesTree.printableTreeString()}")
+        return dependenciesTree to resolvedFiles
+    }
+
+    /**
+     * Loads the dependency tree for the given [description].
+     *
+     * Inlined from [JarRepositoryManager.loadDependenciesTree] to remove the modal progress dialog and allow for more
+     * flexible progress reporting.
+     */
+    @Suppress("LongParameterList") // Not worth grouping up
+    private fun loadDependenciesTree(
+        description: RepositoryLibraryDescription?,
+        version: String,
+        project: Project,
+        shouldDownload: Boolean,
+        exclusions: List<String>,
+        indicator: ProgressIndicator?,
+    ): Pair<ArtifactDependencyNode?, Map<String, File>> {
+        if (description == null) return null to emptyMap()
+        logger.debug("Loading dependencies tree for ${description.getMavenCoordinates(version)}")
+        val repositories = RemoteRepositoriesConfiguration.getInstance(project).repositories
+        logger.debug("Creating remote repositories for [${repositories.joinToString(", ") { it.url }}]")
+        val remotes = createRemoteRepositories(repositories)
+
+        val manager =
+            ArtifactRepositoryManager(
+                JarRepositoryManager.getLocalRepositoryPath(),
+                remotes,
+                object : ProgressConsumer {
+                    override fun consume(@ProgressText message: @ProgressText String?) {
+                        if (message != null) {
+                            logger.debug(message)
+                        }
+                    }
+
+                    override fun isCanceled(): Boolean = indicator?.isCanceled ?: false
+                },
+            )
+
+        val resolvedFiles = mutableMapOf<String, File>()
+        if (shouldDownload) {
+            doDownload(description, version, exclusions, manager, resolvedFiles)
+        }
+
+        logger.debug("Collecting dependencies for ${description.getMavenCoordinates(version)}")
+        val rootNode = manager.collectDependencies(description.groupId, description.artifactId, version)
+        return rootNode to resolvedFiles
+    }
+
+    private fun doDownload(
+        description: RepositoryLibraryDescription,
+        version: String,
+        exclusions: List<String>,
+        manager: ArtifactRepositoryManager,
+        resolvedFiles: MutableMap<String, File>,
+    ) {
+        @Suppress("TooGenericExceptionCaught") // IJPL throws generic exceptions :(
+        try {
+            logger.debug(
+                "Resolving dependencies (downloading jars) for ${description.getMavenCoordinates(version)}"
+            )
+            val allExclusions = ProvidedDependencies.getExclusions() + exclusions
+            val artifacts =
+                manager.resolveDependencyAsArtifact(
+                    description.groupId,
+                    description.artifactId,
+                    version,
+                    EnumSet.of(ArtifactKind.ARTIFACT),
+                    true,
+                    allExclusions,
+                )
+            for (artifact in artifacts) {
+                val coord = "${artifact.groupId}:${artifact.artifactId}:${artifact.version}"
+                val file = artifact.file
+                if (file != null) {
+                    resolvedFiles[coord] = file
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to resolve dependencies for ${description.getMavenCoordinates(version)}", e)
+        }
+    }
+
+    /**
+     * Creates a list of [ArtifactRepositoryManager]'s remote repositories from the given [repositoryDescriptions].
+     *
+     * Inlined from `JarRepositoryManager.AetherJob.createRemoteRepositories`.
+     */
+    private fun createRemoteRepositories(repositoryDescriptions: MutableCollection<RemoteRepositoryDescription>) =
+        buildList {
+            for (repository in repositoryDescriptions) {
+                val authData = obtainAuthenticationData(repository)
+                add(
+                    ArtifactRepositoryManager.createRemoteRepository(
+                        repository.id,
+                        repository.url,
+                        authData,
+                        repository.isAllowSnapshots,
+                    )
+                )
+            }
+        }
+
+    /**
+     * Obtains authentication data for the given remote repository description.
+     *
+     * Inlined from `JarRepositoryAuthenticationDataProvider.obtainAuthenticationData` to allow for easier access and to
+     * avoid potential issues with internal APIs in different IDE versions.
+     *
+     * @param description the description of the remote repository
+     * @return the authentication data, or null if none is found
+     */
+    @Suppress("UnstableApiUsage")
+    @RequiresBackgroundThread
+    private fun obtainAuthenticationData(
+        description: RemoteRepositoryDescription,
+    ): ArtifactRepositoryManager.ArtifactAuthenticationData? {
+        for (extension in JarRepositoryAuthenticationDataProvider.KEY.extensionList) {
+            val authData = extension.provideAuthenticationData(description.url)
+            if (authData != null) {
+                return ArtifactRepositoryManager.ArtifactAuthenticationData(authData.userName, authData.password)
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Converts an [ArtifactDependencyNode] tree to a printable string representation.
+     */
+    private fun ArtifactDependencyNode?.printableTreeString(indent: Int = 0): String = buildString {
+        if (this@printableTreeString == null) {
+            append("null")
+            return@buildString
+        }
+        append(" ".repeat(indent))
+        append("${artifact.groupId}:${artifact.artifactId}:${artifact.version}")
+        if (artifact.classifier != null) append(":${artifact.classifier}")
+        appendLine()
+        dependencies.onEach { append(it.printableTreeString(indent + 2)) }
+    }
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginDependencyService.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginDependencyService.kt
@@ -1,0 +1,304 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.google.gson.GsonBuilder
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
+import io.gitlab.arturbosch.detekt.idea.DetektBundle
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.createDirectories
+import kotlin.io.path.name
+
+/**
+ * Service responsible for managing Detekt plugin dependencies. It handles downloading plugins from Maven repositories
+ * and keeping them in a local folder within the project's .idea directory.
+ *
+ * Reconciliation is triggered from two places: [io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings.loadState]
+ * (when settings are loaded or migrated) and [io.gitlab.arturbosch.detekt.idea.config.DetektConfig.apply]
+ * (when the user clicks Apply/OK in the settings UI). If the user applies settings shortly after a load
+ * (e.g. project open), both can queue a background reconciliation with different plugin lists. Without
+ * serialization, two runs could execute concurrently and interleave file operations (downloads, cleanup,
+ * writing downloaded.json), leading to inconsistent on-disk state or the loadState run overwriting the
+ * apply() result. [reconciliationLock] ensures only one reconciliation runs at a time; the other task
+ * waits and then runs with its plugin list, so the final state is always consistent with the last request.
+ */
+@Suppress("TooManyFunctions") // Unavoidable due to complex logic
+@Service(Service.Level.PROJECT)
+class PluginDependencyService(private val project: Project) {
+    private val logger = logger<PluginDependencyService>()
+    private val gson = GsonBuilder().setPrettyPrinting().create()
+
+    /**
+     * Serializes reconciliation so only one download/cleanup run executes at a time.
+     */
+    private val reconciliationLock = Any()
+
+    /**
+     * Returns the path to the folder where Detekt plugins are stored.
+     */
+    fun getPluginFolder(): Path {
+        val basePath = project.basePath ?: return Paths.get(".idea", "detektPlugins")
+        return Paths.get(basePath, ".idea", "detektPlugins")
+    }
+
+    /**
+     * Returns the path to the JSON file tracking downloaded plugins.
+     */
+    private fun getDownloadedFile(): Path = getPluginFolder().resolve("downloaded.json")
+
+    /**
+     * Reconciles the local plugin folder with the provided Detekt plugins. This will trigger a background task to
+     * download any missing plugins and clean up unused ones.
+     */
+    fun reconcilePlugins(plugins: List<DetektPlugin>) {
+        object : Task.Backgroundable(project, DetektBundle.message("detekt.progress.downloadingPlugins"), true) {
+            override fun run(indicator: ProgressIndicator) {
+                synchronized(reconciliationLock) {
+                    downloadPlugins(plugins, indicator)
+                }
+            }
+
+            override fun onSuccess() {
+                DaemonCodeAnalyzer.getInstance(project).restart()
+            }
+        }
+            .queue()
+    }
+
+    /**
+     * Downloads the specified plugins and their transitive dependencies. Core Detekt and Kotlin dependencies are
+     * automatically filtered out. Granular exclusions defined in [DetektPlugin] are also respected.
+     */
+    @RequiresBackgroundThread
+    private fun downloadPlugins(plugins: List<DetektPlugin>, indicator: ProgressIndicator) {
+        val folder = getPluginFolder()
+        val stateFile = getDownloadedFile()
+        logger.info("Starting download/reconcile of ${plugins.size} plugins in $folder")
+
+        // 1. Resolve all plugins to determine allowed files
+        val resolver = MavenDependencyResolver(project)
+        val allowedFilesStr = mutableSetOf<String>() // Relative paths
+        val resolvedArtifacts = mutableListOf<ResolvedArtifact>()
+
+        val newStatePlugins = mutableListOf<PluginState>()
+        val transitiveFilesMap = mutableMapOf<String, TransitiveFile>()
+
+        for (plugin in plugins) {
+            indicator.text = "Resolving ${plugin.coordinate}..."
+            logger.debug("Resolving plugin: ${plugin.coordinate}")
+            resolvePlugin(
+                resolver,
+                plugin,
+                indicator,
+                allowedFilesStr,
+                resolvedArtifacts,
+                transitiveFilesMap,
+                newStatePlugins,
+            )
+        }
+
+        if (!Files.exists(folder)) {
+            folder.createDirectories()
+        }
+
+        // 2. Delete orphaned files and empty folders
+        cleanupOrphanedFiles(folder, allowedFilesStr)
+
+        // 3. Copy missing jars
+        syncMissingJars(resolvedArtifacts, folder)
+
+        // 4. Save new state
+        saveNewState(newStatePlugins, transitiveFilesMap, stateFile)
+    }
+
+    @Suppress("LongParameterList") // Not really simplifiable
+    private fun resolvePlugin(
+        resolver: MavenDependencyResolver,
+        plugin: DetektPlugin,
+        indicator: ProgressIndicator,
+        allowedFilesStr: MutableSet<String>,
+        resolvedArtifacts: MutableList<ResolvedArtifact>,
+        transitiveFilesMap: MutableMap<String, TransitiveFile>,
+        newStatePlugins: MutableList<PluginState>,
+    ) {
+        val rootNode =
+            resolver.resolve(
+                coordinate = plugin.coordinate,
+                shouldDownload = true,
+                exclusions = plugin.exclusions.toList(),
+                indicator = indicator,
+            )
+
+        if (rootNode != null) {
+            logger.debug("Successfully resolved ${plugin.coordinate}")
+            val allowedNodes = collectAllowedNodes(rootNode, plugin.exclusions)
+
+            val transitiveCoords = mutableListOf<String>()
+            var pluginPath: String? = null
+
+            for (node in allowedNodes) {
+                val file = node.file ?: continue
+                val relativePath = coordToRelativePath(node.coordinate, file.name)
+
+                // Add to global set for orphan cleanup and copying
+                allowedFilesStr.add(relativePath)
+                resolvedArtifacts.add(ResolvedArtifact(node.coordinate, relativePath, file))
+
+                if (node.coordinate == plugin.coordinate) {
+                    pluginPath = relativePath
+                } else {
+                    transitiveCoords.add(node.coordinate)
+                    transitiveFilesMap[node.coordinate] = TransitiveFile(relativePath)
+                }
+            }
+
+            newStatePlugins.add(
+                PluginState(
+                    coordinate = plugin.coordinate,
+                    transitiveDependencies = transitiveCoords,
+                    path = pluginPath ?: "",
+                )
+            )
+        } else {
+            logger.error("Failed to resolve plugin: ${plugin.coordinate}. It will be skipped.")
+        }
+    }
+
+    /**
+     * Traverses the dependency tree and collects all nodes that are allowed to be downloaded. Nodes are excluded if
+     * they are provided by the environment or explicitly unchecked by the user.
+     *
+     * Includes cycle detection to prevent [StackOverflowError] in case of cyclic dependencies.
+     */
+    internal fun collectAllowedNodes(
+        node: MavenDependencyResolver.ResolvedNode,
+        exclusions: Set<String>,
+    ): List<MavenDependencyResolver.ResolvedNode> {
+        val result = mutableListOf<MavenDependencyResolver.ResolvedNode>()
+
+        @Suppress("ReturnCount") // No idea how to trim it further
+        fun traverse(n: MavenDependencyResolver.ResolvedNode, visited: Set<String>) {
+            if (visited.contains(n.coordinate)) {
+                logger.warn("Cycle detected during collection at ${n.coordinate}. Skipping children.")
+                return
+            }
+
+            if (ProvidedDependencies.isProvided(n.groupId, n.artifactId)) return
+
+            val ga = n.coordinate.substringBeforeLast(':')
+            if (exclusions.contains(n.coordinate) || exclusions.contains(ga)) {
+                logger.debug("Dependency explicitly excluded: ${n.coordinate}")
+                return
+            }
+
+            result.add(n)
+            val newVisited = visited + n.coordinate
+            n.children.forEach { traverse(it, newVisited) }
+        }
+
+        traverse(node, emptySet())
+        return result.distinctBy { it.coordinate }
+    }
+
+    private fun cleanupOrphanedFiles(folder: Path, allowedFilesStr: MutableSet<String>) {
+        Files.walk(folder).use { walk ->
+            walk.filter { Files.isRegularFile(it) && it.name.endsWith(".jar") }
+                .forEach { file -> cleanupOrphanedJars(folder, file, allowedFilesStr) }
+        }
+
+        // Cleanup empty directories (bottom-up)
+        Files.walk(folder).use { walk ->
+            walk.filter { Files.isDirectory(it) && it != folder }
+                .sorted(Comparator.reverseOrder())
+                .forEach { dir -> cleanupEmptyDirectory(dir, folder) }
+        }
+    }
+
+    private fun cleanupOrphanedJars(folder: Path, file: Path, allowedFilesStr: MutableSet<String>) {
+        val relative = FileUtil.toSystemIndependentName(folder.relativize(file).toString())
+        if (relative !in allowedFilesStr) {
+            logger.debug("Deleting orphaned jar: $relative")
+            try {
+                Files.delete(file)
+            } catch (e: IOException) {
+                logger.warn("Failed to delete orphaned jar: $relative", e)
+            }
+        }
+    }
+
+    private fun cleanupEmptyDirectory(dir: Path, folder: Path) {
+        try {
+            Files.newDirectoryStream(dir).use { stream ->
+                if (!stream.iterator().hasNext()) {
+                    logger.debug("Deleting empty directory: ${folder.relativize(dir)}")
+                    Files.delete(dir)
+                }
+            }
+        } catch (e: IOException) {
+            logger.warn("Failed to delete potentially empty directory: $dir", e)
+        }
+    }
+
+    private fun syncMissingJars(resolvedArtifacts: MutableList<ResolvedArtifact>, folder: Path) {
+        resolvedArtifacts
+            .distinctBy { it.relativePath }
+            .forEach { artifact ->
+                val target = folder.resolve(artifact.relativePath)
+                if (!Files.exists(target)) {
+                    logger.debug("Copying ${artifact.file.name} to $target")
+                    try {
+                        Files.createDirectories(target.parent)
+                        FileUtil.copy(artifact.file, target.toFile())
+                    } catch (e: IOException) {
+                        logger.error("Failed to copy ${artifact.file} to $target", e)
+                    }
+                }
+            }
+    }
+
+    private fun saveNewState(
+        newStatePlugins: MutableList<PluginState>,
+        transitiveFilesMap: MutableMap<String, TransitiveFile>,
+        stateFile: Path,
+    ) {
+        val newState = DownloadedState(plugins = newStatePlugins, transitiveFiles = transitiveFilesMap)
+        try {
+            Files.writeString(stateFile, gson.toJson(newState))
+            logger.info("Saved downloaded state to $stateFile")
+        } catch (e: IOException) {
+            logger.error("Failed to save downloaded state", e)
+        }
+    }
+
+    /**
+     * Represents the persistent state of downloaded plugins.
+     */
+    private data class DownloadedState(
+        val plugins: List<PluginState> = emptyList(),
+        val transitiveFiles: Map<String, TransitiveFile> = emptyMap(),
+    )
+
+    /**
+     * Represents the state of a single plugin and its transitive dependencies.
+     */
+    private data class PluginState(val coordinate: String, val transitiveDependencies: List<String>, val path: String)
+
+    /**
+     * Represents a file path for a transitive dependency.
+     */
+    private data class TransitiveFile(val path: String)
+
+    /**
+     * Represents an artifact that has been resolved and is ready to be copied.
+     */
+    private data class ResolvedArtifact(val coord: String, val relativePath: String, val file: File)
+}

--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProvidedDependencies.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProvidedDependencies.kt
@@ -1,0 +1,24 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+/**
+ * Utility for determining which Maven dependencies are provided by the environment.
+ *
+ * These are typically dependencies provided by the detekt-intellij-plugin itself or the underlying IntelliJ platform
+ * (detekt-api, kotlin-stdlib, etc.).
+ */
+object ProvidedDependencies {
+
+    private val PROVIDED_GROUP_IDS = setOf("io.gitlab.arturbosch.detekt", "dev.detekt", "org.jetbrains.kotlin")
+
+    /** Returns true if the given dependency is provided by the environment. */
+    fun isProvided(groupId: String, artifactId: String): Boolean {
+        if (groupId == "org.jetbrains.kotlinx") {
+            return artifactId.startsWith("kotlinx-coroutines-")
+        }
+        return groupId in PROVIDED_GROUP_IDS
+    }
+
+    /** Returns a list of Maven exclusion strings for all provided dependencies. */
+    fun getExclusions(): List<String> =
+        PROVIDED_GROUP_IDS.map { "$it:*" } + "org.jetbrains.kotlinx:kotlinx-coroutines-*"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,8 +11,11 @@
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.kotlin</depends>
+    <depends>org.jetbrains.idea.maven</depends>
 
-    <idea-version since-build="223.7571.182"/>
+    <idea-version since-build="242.20224.300"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Turn off error reporting for now due to https://github.com/detekt/detekt-intellij-plugin/issues/271 -->
@@ -21,6 +24,7 @@
 
         <projectService serviceImplementation="io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings"/>
         <projectService serviceImplementation="io.gitlab.arturbosch.detekt.idea.config.DetektSettingsMigration"/>
+        <projectService serviceImplementation="io.gitlab.arturbosch.detekt.idea.util.PluginDependencyService"/>
 
         <!--suppress PluginXmlI18n -->
         <projectConfigurable groupId="tools"
@@ -35,6 +39,10 @@
                     icon="DetektIcons.DocsToolWindow"/>
 
         <iconMapper mappingFile="DetektIconMappings.json"/>
+    </extensions>
+
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true"/>
     </extensions>
 
     <applicationListeners>

--- a/src/main/resources/messages/detektBundle.properties
+++ b/src/main/resources/messages/detektBundle.properties
@@ -12,10 +12,13 @@ detekt.configuration.configurationFiles.comment=These YAML files configure the r
 detekt.configuration.baselineFile.title=Baseline file:
 detekt.configuration.baselineFile.dialog.title=Choose Detekt Baseline File
 detekt.configuration.baselineFile.comment=The baseline XML file informs Detekt of "known" issues that it should not emit warnings for. <a href="https://detekt.dev/docs/introduction/baseline">Learn more</a>
-detekt.configuration.pluginJarFiles.title=Plugin JAR(s):
-detekt.configuration.pluginJarFiles.dialog.title=Detekt Plugin JAR File(s)
-detekt.configuration.pluginJarFiles.dialog.description=Select any number of Detekt plugin files (*.jar) to add
-detekt.configuration.pluginJarFiles.comment=Plugin JARs to add to the detekt classpath. <a href="https://detekt.dev/docs/introduction/extensions">Learn more</a>
+detekt.configuration.mavenSearch.title=Add from Maven repositories
+detekt.configuration.mavenSearch.searchLabel=Search:
+detekt.configuration.mavenSearch.searchButton=Search
+detekt.configuration.mavenSearch.tableHeader.group=Group
+detekt.configuration.mavenSearch.tableHeader.artifact=Artifact
+detekt.configuration.mavenSearch.tableHeader.latestVersion=Latest Version
+detekt.configuration.mavenSearch.versionLabel=Version:
 detekt.configuration.rulesGroup.title=Rules
 detekt.configuration.filesGroup.title=Files
 detekt.notifications.actions.openSettings=Open Detekt Settings
@@ -31,3 +34,16 @@ detekt.notification.enableDetekt.title=Enable detekt
 detekt.notification.enableDetekt.description=The detekt plugin is disabled by default. Do you want to enable it for this project?
 detekt.notification.enableDetekt.enable=Enable
 detekt.notification.enableDetekt.optOut=Don't ask again for this project
+detekt.configuration.plugins.title=Plugins:
+detekt.configuration.plugins.dialog.title.jar=Select Detekt Plugin JAR(s)
+detekt.configuration.plugins.dialog.description.jar=Select any number of Detekt plugin files (*.jar) to add
+detekt.configuration.plugins.comment=Add plugins to the detekt classpath. They can be local JAR files or Maven coordinates. <a href="https://detekt.dev/docs/introduction/extensions">Learn more</a>
+detekt.configuration.mavenSearch.customize=Customize
+detekt.configuration.mavenSearch.resolvingTransitive=Resolving transitive dependencies for {0}...
+detekt.configuration.mavenSearch.failedToResolve=Failed to resolve dependencies.
+detekt.configuration.mavenSearch.includesTransitive=Includes {0} transitive dependencies
+detekt.configuration.mavenSearch.copyCoordinates=&Copy coordinates
+tooltip.text.dependency.is.provided=This dependency is provided by the Detekt IntelliJ plugin or the IntelliJ Platform itself.
+detekt.configuration.mavenSearch.marketplaceBlurb=Looking for inspiration? Check the <a href="https://detekt.dev/marketplace">Marketplace</a>.<br/>This search uses the <a href="https://www.jetbrains.com/help/idea/maven-repositories.html">Maven repositories</a> configured in your IDE.
+detekt.configuration.mavenSearch.noResults=No results found
+detekt.progress.downloadingPlugins=Downloading Detekt Plugins

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/ConfiguredServiceTest.kt
@@ -59,13 +59,7 @@ class ConfiguredServiceTest : MockProjectTestCase() {
         val service = ConfiguredService(project)
         val testPath = resourceAsPath("testData/Poko.kt")
 
-        assertThat(
-            service.execute(
-                testPath.readText(),
-                testPath.toString(),
-                autoCorrect = false
-            )
-        ).isNotEmpty
+        assertThat(service.execute(testPath.readText(), testPath.toString(), autoCorrect = false)).isNotEmpty
     }
 
     @Test
@@ -74,5 +68,19 @@ class ConfiguredServiceTest : MockProjectTestCase() {
 
         assertThat(service.execute("", SPECIAL_FILENAME_FOR_DEBUGGING, false)).isEmpty()
         assertThat(service.execute("", SPECIAL_FILENAME_AI_SNIPPED, false)).isEmpty()
+    }
+
+    @Test
+    fun `finds downloaded plugins in subfolders`() {
+        val pluginFolder = tempDir.resolve(".idea/detektPlugins")
+        val subfolder = pluginFolder.resolve("com/example/1.0.0")
+        java.nio.file.Files.createDirectories(subfolder)
+        val jarFile = subfolder.resolve("plugin.jar")
+        java.nio.file.Files.createFile(jarFile)
+
+        val service = ConfiguredService(project)
+        val paths = service.pluginPaths()
+
+        assertThat(paths).contains(jarFile)
     }
 }

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/KotlinParsingTestCase.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/KotlinParsingTestCase.kt
@@ -5,14 +5,17 @@ import com.intellij.mock.MockPsiFile
 import com.intellij.mock.MockVirtualFile
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.readText
 
@@ -22,9 +25,14 @@ open class KotlinParsingTestCase : MockProjectTestCase() {
     private lateinit var rootDisposable: Disposable
 
     @BeforeAll
-    override fun setUp() {
+    fun setUpProject(@TempDir tempDir: Path) {
         rootDisposable = Disposable { }
-        project = heavyMockProject(rootDisposable)
+        project = heavyMockProject(rootDisposable, tempDir.toString())
+    }
+
+    override fun setupProjectAndConfig() {
+        val config = project.service<DetektPluginSettings>()
+        config.loadState(DetektPluginSettings.State())
     }
 
     @AfterAll
@@ -34,7 +42,7 @@ open class KotlinParsingTestCase : MockProjectTestCase() {
         ApplicationManager.setApplication(
             MockApplication(rootDisposable),
             { FileTypeManager.getInstance() },
-            rootDisposable
+            rootDisposable,
         )
     }
 

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/MockProjectTestCase.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/MockProjectTestCase.kt
@@ -3,9 +3,10 @@ package io.gitlab.arturbosch.detekt.idea
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import io.gitlab.arturbosch.detekt.idea.config.DetektPluginSettings
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 open class MockProjectTestCase {
@@ -18,14 +19,12 @@ open class MockProjectTestCase {
 
     protected lateinit var project: Project
 
+    @TempDir lateinit var tempDir: Path
+
     @BeforeEach
-    open fun clearConfig() {
+    open fun setupProjectAndConfig() {
+        project = mockProject(tempDir.toString())
         val config = project.service<DetektPluginSettings>()
         config.loadState(DetektPluginSettings.State())
-    }
-
-    @BeforeAll
-    open fun setUp() {
-        project = mockProject()
     }
 }

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencyCycleTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencyCycleTest.kt
@@ -1,0 +1,71 @@
+package io.gitlab.arturbosch.detekt.idea.config.logic
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DependencyCycleTest {
+
+    @Test
+    fun `direct cycle does not cause stack overflow during propagation`() {
+        val node = TestNode("g", "a")
+        node.addChild(node) // A -> A cycle
+
+        node.isChecked = false
+        // Should not throw StackOverflowError
+        sync(node, listOf(node))
+        assertFalse(node.isChecked)
+    }
+
+    @Test
+    fun `indirect cycle does not cause stack overflow during propagation`() {
+        val nodeA = TestNode("g", "a")
+        val nodeB = TestNode("g", "b")
+        nodeA.addChild(nodeB)
+        nodeB.addChild(nodeA) // A -> B -> A cycle
+
+        nodeA.isChecked = false
+        // Should not throw StackOverflowError
+        sync(nodeA, listOf(nodeA, nodeB))
+
+        assertFalse(nodeA.isChecked)
+        assertFalse(nodeB.isChecked)
+    }
+
+    @Test
+    fun `multiple paths to same node do not cause issues`() {
+        // This is a diamond, not a cycle, but tests recursion depth/visit tracking
+        val root = TestNode("root", "r")
+        val left = TestNode("left", "l")
+        val right = TestNode("right", "r")
+        val bottom = TestNode("bottom", "b")
+
+        root.addChild(left)
+        root.addChild(right)
+        left.addChild(bottom)
+        right.addChild(bottom)
+
+        root.isChecked = false
+        // Should not throw StackOverflowError
+        sync(root, listOf(root, left, right, bottom))
+
+        assertFalse(root.isChecked)
+        assertFalse(left.isChecked)
+        assertFalse(right.isChecked)
+        assertFalse(bottom.isChecked)
+    }
+
+    @Test
+    fun `checking child in cyclic dependency propagates to ancestors`() {
+        val nodeA = TestNode("g", "a", initialChecked = false)
+        val nodeB = TestNode("g", "b", initialChecked = false, parent = nodeA)
+        nodeA.addChild(nodeB)
+        nodeB.addChild(nodeA) // Cycle
+
+        nodeB.isChecked = true
+        sync(nodeB, listOf(nodeA, nodeB))
+
+        assertTrue(nodeB.isChecked)
+        assertTrue(nodeA.isChecked, "Parent nodeA should have been checked by propagation from child nodeB")
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencySelectionHandlerTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/DependencySelectionHandlerTest.kt
@@ -1,0 +1,201 @@
+package io.gitlab.arturbosch.detekt.idea.config.logic
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DependencySelectionHandlerTest {
+
+    @Test
+    fun `provided nodes stay checked`() {
+        val node = TestNode("g", "a", isProvided = true, initialChecked = true)
+        node.isChecked = false // simulate UI uncheck
+
+        sync(node, listOf(node))
+
+        assertTrue(node.isChecked, "Provided node should have been forced back to checked")
+    }
+
+    @Test
+    fun `global synchronization works`() {
+        val node1 = TestNode("g", "a", initialChecked = true)
+        val node2 = TestNode("g", "a", initialChecked = true)
+        val other = TestNode("g", "b", initialChecked = true)
+        val allNodes = listOf(node1, node2, other)
+
+        node1.isChecked = false
+        sync(node1, allNodes)
+
+        assertFalse(node2.isChecked, "Second instance of same artifact should be unchecked")
+        assertTrue(other.isChecked, "Unrelated artifact should remain checked")
+    }
+
+    @Test
+    fun `children propagation works`() {
+        val parent = TestNode("p", "a")
+        val child = TestNode("c", "b", parent = parent)
+        parent.addChild(child)
+
+        parent.isChecked = false
+        sync(parent, listOf(parent, child))
+
+        assertFalse(child.isChecked, "Child should be unchecked when parent is unchecked")
+    }
+
+    @Test
+    fun `provided children are not unchecked`() {
+        val parent = TestNode("p", "a")
+        val child = TestNode("c", "b", isProvided = true, parent = parent)
+        parent.addChild(child)
+
+        parent.isChecked = false
+        sync(parent, listOf(parent, child))
+
+        assertFalse(parent.isChecked)
+        assertTrue(child.isChecked, "Provided child should remain checked even if parent is unchecked")
+    }
+
+    @Test
+    fun `parent propagation works`() {
+        val parent = TestNode("p", "a", initialChecked = false)
+        val child = TestNode("c", "b", initialChecked = false, parent = parent)
+        parent.addChild(child)
+
+        child.isChecked = true
+        sync(child, listOf(parent, child))
+
+        assertTrue(parent.isChecked, "Parent should be checked when child is checked")
+    }
+
+    @Test
+    fun `provided nodes do not propagate to parents`() {
+        val parent = TestNode("p", "a", initialChecked = false)
+        val child = TestNode("c", "b", isProvided = true, initialChecked = true, parent = parent)
+        parent.addChild(child)
+
+        // Simulate child triggering sync (e.g. during initial protection logic)
+        sync(child, listOf(parent, child))
+
+        assertFalse(parent.isChecked, "Provided child should not force parent to be checked")
+    }
+
+    @Test
+    fun `complex scenario uncheck parent with provided child and non-provided child`() {
+        val parent = TestNode("p", "a")
+        val providedChild = TestNode("c", "provided", isProvided = true, parent = parent)
+        val normalChild = TestNode("c", "normal", parent = parent)
+        parent.addChild(providedChild)
+        parent.addChild(normalChild)
+
+        val allNodes = listOf(parent, providedChild, normalChild)
+
+        parent.isChecked = false
+        sync(parent, allNodes)
+
+        assertFalse(parent.isChecked)
+        assertTrue(providedChild.isChecked, "Provided child stays")
+        assertFalse(normalChild.isChecked, "Normal child goes")
+    }
+
+    @Test
+    fun `regression test - nlopez compose rules behavior`() {
+        // Root is invisible, but for our test we'll use a dummy root
+        val dummyRoot = TestNode("root", "root", isProvided = true)
+
+        // Siblings at top level
+        val topDetektCore = TestNode("dev.detekt", "detekt-core", isProvided = true, parent = dummyRoot)
+        val ioNlopez = TestNode("io.nlopez.compose.rules", "common-detekt", isProvided = false, parent = dummyRoot)
+        val topKotlinStdlib = TestNode("org.jetbrains.kotlin", "kotlin-stdlib", isProvided = true, parent = dummyRoot)
+
+        dummyRoot.addChild(topDetektCore)
+        dummyRoot.addChild(ioNlopez)
+        dummyRoot.addChild(topKotlinStdlib)
+
+        // Children of ioNlopez
+        val childDetektCore = TestNode("dev.detekt", "detekt-core", isProvided = true, parent = ioNlopez)
+        val childDetektPsi = TestNode("dev.detekt", "detekt-psi-utils", isProvided = true, parent = ioNlopez)
+        val childKotlinStdlib = TestNode("org.jetbrains.kotlin", "kotlin-stdlib", isProvided = true, parent = ioNlopez)
+
+        ioNlopez.addChild(childDetektCore)
+        ioNlopez.addChild(childDetektPsi)
+        ioNlopez.addChild(childKotlinStdlib)
+
+        val allNodes =
+            listOf(
+                dummyRoot,
+                topDetektCore,
+                ioNlopez,
+                topKotlinStdlib,
+                childDetektCore,
+                childDetektPsi,
+                childKotlinStdlib,
+            )
+
+        // Initial state: all checked
+        assertTrue(ioNlopez.isChecked)
+
+        // Action: uncheck ioNlopez
+        ioNlopez.isChecked = false
+        sync(ioNlopez, allNodes)
+
+        // Verification
+        assertFalse(ioNlopez.isChecked, "The clicked node should definitely be unchecked")
+        assertTrue(topDetektCore.isChecked, "Provided sibling should stay checked")
+        assertTrue(childDetektCore.isChecked, "Provided child should stay checked")
+    }
+
+    @Test
+    fun `deeply nested tree propagation 4 levels`() {
+        val root = TestNode("root", "a", initialChecked = true)
+        val level1 = TestNode("level1", "b", initialChecked = true, parent = root)
+        val level2 = TestNode("level2", "c", initialChecked = true, parent = level1)
+        val level3 = TestNode("level3", "d", initialChecked = true, parent = level2)
+        val level4 = TestNode("level4", "e", initialChecked = true, parent = level3)
+
+        root.addChild(level1)
+        level1.addChild(level2)
+        level2.addChild(level3)
+        level3.addChild(level4)
+
+        val allNodes = listOf(root, level1, level2, level3, level4)
+
+        // Uncheck root should uncheck all descendants
+        root.isChecked = false
+        sync(root, allNodes)
+
+        assertFalse(root.isChecked)
+        assertFalse(level1.isChecked, "Level 1 should be unchecked")
+        assertFalse(level2.isChecked, "Level 2 should be unchecked")
+        assertFalse(level3.isChecked, "Level 3 should be unchecked")
+        assertFalse(level4.isChecked, "Level 4 should be unchecked")
+    }
+
+    @Test
+    fun `root node with no parent checks correctly`() {
+        val root = TestNode("root", "a", initialChecked = false, parent = null)
+
+        root.isChecked = true
+        sync(root, listOf(root))
+
+        // Should not throw and root should remain checked
+        assertTrue(root.isChecked, "Root should stay checked")
+    }
+
+    @Test
+    fun `unchecking node does not affect siblings`() {
+        val parent = TestNode("parent", "a")
+        val child1 = TestNode("sibling1", "b", initialChecked = true, parent = parent)
+        val child2 = TestNode("sibling2", "c", initialChecked = true, parent = parent)
+        parent.addChild(child1)
+        parent.addChild(child2)
+
+        val allNodes = listOf(parent, child1, child2)
+
+        child1.isChecked = false
+        sync(child1, allNodes)
+
+        assertFalse(child1.isChecked, "Clicked node should be unchecked")
+        assertTrue(child2.isChecked, "Sibling should remain checked")
+        assertTrue(parent.isChecked, "Parent should remain checked")
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/TestNode.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/logic/TestNode.kt
@@ -1,0 +1,26 @@
+package io.gitlab.arturbosch.detekt.idea.config.logic
+
+internal class TestNode(
+    override val groupId: String,
+    override val artifactId: String,
+    override val isProvided: Boolean = false,
+    initialChecked: Boolean = true,
+    override val parent: TestNode? = null,
+) : SyncableNode {
+    override var isChecked: Boolean = initialChecked
+    override val children = mutableListOf<TestNode>()
+
+    override fun updateChecked(checked: Boolean) {
+        isChecked = checked
+    }
+
+    fun addChild(child: TestNode) {
+        children.add(child)
+    }
+}
+
+internal fun sync(node: SyncableNode, allNodes: Iterable<SyncableNode>) {
+    DependencySelectionHandler.syncArtifacts(node, allNodes) { n, state ->
+        (n as TestNode).updateChecked(state)
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DependencyExclusionEditorTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/DependencyExclusionEditorTest.kt
@@ -1,0 +1,54 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import io.gitlab.arturbosch.detekt.idea.util.MavenDependencyResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import javax.swing.tree.TreeNode
+
+class DependencyExclusionEditorTest {
+
+    @Test
+    fun `buildDependencyTreeNode keeps children even when root is provided`() {
+        val child =
+            node(
+                groupId = "com.example",
+                artifactId = "child",
+                isProvided = false,
+                children = emptyList(),
+            )
+        val root =
+            node(
+                groupId = "io.gitlab.arturbosch.detekt",
+                artifactId = "detekt-formatting",
+                isProvided = true,
+                children = listOf(child),
+            )
+
+        val treeNode = buildDependencyTreeNode(root)
+
+        assertThat(treeNode.childCount).isEqualTo(1)
+        assertThat(treeNode.isEnabled).isFalse()
+        val onlyChild = treeNode.getChildAt(0) as TreeNode
+        assertThat((onlyChild as com.intellij.ui.CheckedTreeNode).isEnabled).isTrue()
+    }
+
+    private fun node(
+        groupId: String,
+        artifactId: String,
+        isProvided: Boolean,
+        children: List<MavenDependencyResolver.ResolvedNode>,
+    ): MavenDependencyResolver.ResolvedNode {
+        val version = "1.0.0"
+        val coordinate = "$groupId:$artifactId:$version"
+        return MavenDependencyResolver.ResolvedNode(
+            groupId = groupId,
+            artifactId = artifactId,
+            version = version,
+            coordinate = coordinate,
+            isProvided = isProvided,
+            isRejected = false,
+            children = children,
+            file = null,
+        )
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenArtifactFetcherTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/config/ui/MavenArtifactFetcherTest.kt
@@ -1,0 +1,560 @@
+package io.gitlab.arturbosch.detekt.idea.config.ui
+
+import com.intellij.jarRepository.RepositoryArtifactDescription
+import io.gitlab.arturbosch.detekt.idea.MockProjectTestCase
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+
+class MavenArtifactFetcherTest : MockProjectTestCase() {
+
+    @Nested
+    inner class MavenArtifactTest {
+
+        @Test
+        fun `latestVersion returns first version`() {
+            val artifact = MavenArtifact("group", "artifact", listOf("2.0.0", "1.0.0"))
+            assertThat(artifact.latestVersion).isEqualTo("2.0.0")
+        }
+
+        @Test
+        fun `latestVersion returns null for empty versions`() {
+            val artifact = MavenArtifact("group", "artifact", emptyList())
+            assertThat(artifact.latestVersion).isNull()
+        }
+    }
+
+    @Nested
+    inner class DeduplicateByVersion {
+
+        @Test
+        fun `deduplicates artifacts by highest version`() {
+            val artifacts =
+                listOf(
+                    createArtifact("group", "artifact", "1.0.0"),
+                    createArtifact("group", "artifact", "1.1.0"),
+                    createArtifact("group", "artifact", "1.0.1"),
+                    createArtifact("other", "artifact", "2.0.0"),
+                )
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(2)
+            val groupArtifact = result.find { it.groupId == "group" && it.artifactId == "artifact" }
+            assertThat(groupArtifact?.version).isEqualTo("1.1.0")
+
+            val otherArtifact = result.find { it.groupId == "other" && it.artifactId == "artifact" }
+            assertThat(otherArtifact?.version).isEqualTo("2.0.0")
+        }
+
+        @Test
+        fun `handles empty collection`() {
+            val result = MavenArtifactFetcher.deduplicateByVersion(emptyList())
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `handles single artifact`() {
+            val artifacts = listOf(createArtifact("group", "artifact", "1.0.0"))
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].version).isEqualTo("1.0.0")
+        }
+
+        @Test
+        fun `compares semantic versions correctly`() {
+            val artifacts =
+                listOf(
+                    createArtifact("group", "artifact", "1.9.0"),
+                    createArtifact("group", "artifact", "1.10.0"),
+                    createArtifact("group", "artifact", "1.2.0"),
+                )
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].version).isEqualTo("1.10.0")
+        }
+
+        @Test
+        fun `handles prerelease versions`() {
+            val artifacts =
+                listOf(
+                    createArtifact("group", "artifact", "1.0.0-alpha"),
+                    createArtifact("group", "artifact", "1.0.0"),
+                    createArtifact("group", "artifact", "1.0.0-beta"),
+                )
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].version).isEqualTo("1.0.0")
+        }
+
+        @Test
+        fun `keeps multiple artifacts with different groupIds`() {
+            val artifacts =
+                listOf(
+                    createArtifact("io.detekt", "api", "1.0.0"),
+                    createArtifact("io.other", "api", "2.0.0"),
+                    createArtifact("io.another", "api", "3.0.0"),
+                )
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(3)
+        }
+
+        @Test
+        fun `keeps multiple artifacts with different artifactIds`() {
+            val artifacts =
+                listOf(
+                    createArtifact("io.detekt", "api", "1.0.0"),
+                    createArtifact("io.detekt", "core", "2.0.0"),
+                    createArtifact("io.detekt", "rules", "3.0.0"),
+                )
+
+            val result = MavenArtifactFetcher.deduplicateByVersion(artifacts)
+
+            assertThat(result).hasSize(3)
+        }
+    }
+
+    @Nested
+    inner class SortVersionsDescending {
+
+        @Test
+        fun `sorts versions in descending order`() {
+            val versions = listOf("1.0.0", "2.0.0", "1.5.0", "3.0.0")
+
+            val result = MavenArtifactFetcher.sortVersionsDescending(versions)
+
+            assertThat(result).containsExactly("3.0.0", "2.0.0", "1.5.0", "1.0.0")
+        }
+
+        @Test
+        fun `handles empty collection`() {
+            val result = MavenArtifactFetcher.sortVersionsDescending(emptyList())
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `handles single version`() {
+            val result = MavenArtifactFetcher.sortVersionsDescending(listOf("1.0.0"))
+            assertThat(result).containsExactly("1.0.0")
+        }
+
+        @Test
+        fun `sorts semantic versions correctly`() {
+            val versions = listOf("1.9.0", "1.10.0", "1.2.0", "2.0.0")
+
+            val result = MavenArtifactFetcher.sortVersionsDescending(versions)
+
+            assertThat(result).containsExactly("2.0.0", "1.10.0", "1.9.0", "1.2.0")
+        }
+
+        @Test
+        fun `sorts prerelease versions correctly`() {
+            val versions = listOf("1.0.0-alpha", "1.0.0", "1.0.0-beta", "1.0.0-rc1")
+
+            val result = MavenArtifactFetcher.sortVersionsDescending(versions)
+
+            assertThat(result[0]).isEqualTo("1.0.0")
+        }
+
+        @Test
+        fun `sorts complex version strings`() {
+            val versions = listOf("1.0.0-SNAPSHOT", "1.0.0", "1.0.1", "1.0.0-beta.2", "1.0.0-beta.1")
+
+            val result = MavenArtifactFetcher.sortVersionsDescending(versions)
+
+            assertThat(result[0]).isEqualTo("1.0.1")
+            assertThat(result[1]).isEqualTo("1.0.0")
+        }
+    }
+
+    @Nested
+    inner class MavenGavParseTest {
+
+        @Test
+        fun `parses standard GAV coordinate`() {
+            val result = MavenArtifactFetcher.parseGav("io.detekt:detekt-api:1.23.0")
+            assertThat(result).isNotNull
+            assertThat(result?.groupId).isEqualTo("io.detekt")
+            assertThat(result?.artifactId).isEqualTo("detekt-api")
+            assertThat(result?.version).isEqualTo("1.23.0")
+        }
+
+        @Test
+        fun `parses group and artifact coordinate`() {
+            val result = MavenArtifactFetcher.parseGav("io.detekt:detekt-api")
+            assertThat(result).isNotNull
+            assertThat(result?.groupId).isEqualTo("io.detekt")
+            assertThat(result?.artifactId).isEqualTo("detekt-api")
+            assertThat(result?.version).isNull()
+        }
+
+        @Test
+        fun `parses GAV with packaging`() {
+            val result = MavenArtifactFetcher.parseGav("io.detekt:detekt-api:jar:1.23.0")
+            assertThat(result).isNotNull
+            assertThat(result?.groupId).isEqualTo("io.detekt")
+            assertThat(result?.artifactId).isEqualTo("detekt-api")
+            assertThat(result?.version).isEqualTo("1.23.0")
+        }
+
+        @Test
+        fun `trims parts during parsing`() {
+            val result = MavenArtifactFetcher.parseGav(" io.detekt : detekt-api : 1.23.0 ")
+            assertThat(result).isNotNull
+            assertThat(result?.groupId).isEqualTo("io.detekt")
+            assertThat(result?.artifactId).isEqualTo("detekt-api")
+            assertThat(result?.version).isEqualTo("1.23.0")
+        }
+
+        @Test
+        fun `returns null for incomplete GAV`() {
+            assertThat(MavenArtifactFetcher.parseGav("io.detekt")).isNull()
+        }
+
+        @Test
+        fun `returns null for blank parts`() {
+            assertThat(MavenArtifactFetcher.parseGav("io.detekt::1.23.0")).isNull()
+            assertThat(MavenArtifactFetcher.parseGav(":detekt-api:1.23.0")).isNull()
+            assertThat(MavenArtifactFetcher.parseGav("io.detekt:detekt-api:")).isNull()
+        }
+
+        @Test
+        fun `returns null for non-GAV strings`() {
+            assertThat(MavenArtifactFetcher.parseGav("just a search term")).isNull()
+            assertThat(MavenArtifactFetcher.parseGav("")).isNull()
+        }
+    }
+
+    @Nested
+    inner class CreateArtifactKey {
+
+        @Test
+        fun `creates key from groupId and artifactId`() {
+            val key = MavenArtifactFetcher.createArtifactKey("io.detekt", "api")
+            assertThat(key).isEqualTo("io.detekt:api")
+        }
+
+        @Test
+        fun `handles complex groupIds`() {
+            val key = MavenArtifactFetcher.createArtifactKey("io.gitlab.arturbosch.detekt", "detekt-formatting")
+            assertThat(key).isEqualTo("io.gitlab.arturbosch.detekt:detekt-formatting")
+        }
+    }
+
+    @Nested
+    inner class RunCallablesWithTimeoutAndShutdown {
+
+        @Test
+        fun `returns results from all callables when they complete within timeout`() {
+            val callables: List<Callable<Int>> =
+                listOf(
+                    Callable { 1 },
+                    Callable { 2 },
+                    Callable { 3 },
+                )
+            val result: List<Int> =
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdown(
+                    callables = callables,
+                    timeoutMs = 5000L,
+                    shutdownTimeoutMs = 1000L,
+                )
+            assertThat(result).containsExactly(1, 2, 3)
+        }
+
+        @Test
+        fun `returns empty list for empty callables`() {
+            val result: List<Int> =
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdown(
+                    callables = emptyList<Callable<Int>>(),
+                    timeoutMs = 1000L,
+                    shutdownTimeoutMs = 1000L,
+                )
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `throws TimeoutException when a callable exceeds timeout and executor is shut down`() {
+            val interrupted = AtomicBoolean(false)
+            val callables: List<Callable<Int>> =
+                listOf(
+                    Callable {
+                        try {
+                            Thread.sleep(60_000)
+                        } catch (e: InterruptedException) {
+                            interrupted.set(true)
+                            throw e
+                        }
+                        1
+                    },
+                )
+            assertThatThrownBy {
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdown(
+                    callables = callables,
+                    timeoutMs = 50L,
+                    shutdownTimeoutMs = 2000L,
+                )
+            }.isInstanceOf(TimeoutException::class.java)
+
+            // shutdownNow() interrupts running tasks; give the worker a moment to see it
+            Thread.sleep(100)
+            assertThat(interrupted.get()).describedAs("Executor must interrupt long-running task on timeout").isTrue()
+        }
+
+        @Test
+        fun `throws ExecutionException when a callable throws and executor is still shut down`() {
+            val callables: List<Callable<Int>> =
+                listOf(
+                    Callable { 1 },
+                    Callable { error("task failed") },
+                )
+            assertThatThrownBy {
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdown(
+                    callables = callables,
+                    timeoutMs = 5000L,
+                    shutdownTimeoutMs = 1000L,
+                )
+            }.isInstanceOf(ExecutionException::class.java)
+                .hasCauseInstanceOf(RuntimeException::class.java)
+                .hasMessageContaining("task failed")
+        }
+
+        @Test
+        fun `propagates InterruptedException and shuts down executor`() {
+            val callables: List<Callable<Int>> =
+                listOf(
+                    Callable {
+                        Thread.sleep(30_000)
+                        1
+                    },
+                )
+            val thread =
+                Thread {
+                    try {
+                        MavenArtifactFetcher.runCallablesWithTimeoutAndShutdown(
+                            callables = callables,
+                            timeoutMs = 5000L,
+                            shutdownTimeoutMs = 1000L,
+                        )
+                    } catch (_: InterruptedException) {
+                        // expected when we interrupt
+                    }
+                }
+            thread.start()
+            Thread.sleep(50)
+            thread.interrupt()
+            thread.join(3000)
+            assertThat(thread.isAlive).describedAs("Caller thread should exit after interrupt").isFalse()
+        }
+    }
+
+    @Nested
+    inner class RetryOnceOnTimeout {
+
+        @Test
+        fun `retries once when timeout occurs`() {
+            var attempts = 0
+            val result =
+                MavenArtifactFetcher.retryOnceOnTimeout {
+                    attempts += 1
+                    if (attempts == 1) throw TimeoutException("first attempt")
+                    "ok"
+                }
+
+            assertThat(result).isEqualTo("ok")
+            assertThat(attempts).isEqualTo(2)
+        }
+
+        @Test
+        fun `propagates timeout when both attempts fail`() {
+            assertThatThrownBy {
+                MavenArtifactFetcher.retryOnceOnTimeout<String> {
+                    throw TimeoutException("always")
+                }
+            }.isInstanceOf(TimeoutException::class.java)
+        }
+    }
+
+    @Nested
+    inner class RunCallablesWithTimeoutAndShutdownUsingFallback {
+
+        @Test
+        fun `returns fallback for timed out callable and keeps successful results`() {
+            val callables: List<Callable<String>> =
+                listOf(
+                    Callable { "ok" },
+                    Callable {
+                        Thread.sleep(60_000)
+                        "late"
+                    },
+                )
+
+            val result =
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdownUsingFallback(
+                    callables = callables,
+                    timeoutMs = 50L,
+                    shutdownTimeoutMs = 1000L,
+                    fallback = { index -> "fallback-$index" },
+                )
+
+            assertThat(result).containsExactly("ok", "fallback-1")
+        }
+
+        @Test
+        fun `returns fallback when callable throws`() {
+            val callables: List<Callable<String>> =
+                listOf(
+                    Callable { "ok" },
+                    Callable { error("boom") },
+                )
+
+            val result =
+                MavenArtifactFetcher.runCallablesWithTimeoutAndShutdownUsingFallback(
+                    callables = callables,
+                    timeoutMs = 5000L,
+                    shutdownTimeoutMs = 1000L,
+                    fallback = { index -> "fallback-$index" },
+                )
+
+            assertThat(result).containsExactly("ok", "fallback-1")
+        }
+    }
+
+    @Nested
+    inner class SearchArtifacts {
+
+        @Test
+        fun `returns empty list when search backend throws`() {
+            val scheduler = Executors.newSingleThreadScheduledExecutor()
+            try {
+                val fetcher =
+                    MavenArtifactFetcher(
+                        project = project,
+                        searchTimeout = 50.milliseconds,
+                        searchBackend =
+                            ArtifactSearchBackend { _, _, _ ->
+                                throw IllegalStateException("backend down")
+                            },
+                        versionsFetcher = VersionsFetcher { error("should not be called") },
+                        scheduler = scheduler,
+                    )
+
+                val result = CompletableFuture<List<MavenArtifact>>()
+                fetcher.searchArtifacts("detekt") { result.complete(it) }
+
+                assertThat(result.get(1, TimeUnit.SECONDS)).isEmpty()
+            } finally {
+                scheduler.shutdownNow()
+            }
+        }
+
+        @Test
+        fun `keeps versions for successful artifacts when one times out`() {
+            val scheduler = Executors.newSingleThreadScheduledExecutor()
+            try {
+                val artifactA = createArtifact("io.example", "a", "1.0.0")
+                val artifactB = createArtifact("io.example", "b", "2.0.0")
+                val fetcher =
+                    MavenArtifactFetcher(
+                        project = project,
+                        searchTimeout = 50.milliseconds,
+                        searchBackend = ArtifactSearchBackend { _, _, onResults ->
+                            onResults(listOf(artifactA, artifactB))
+                        },
+                        versionsFetcher = VersionsFetcher { artifacts ->
+                            artifacts.map { artifact ->
+                                if (artifact.artifactId == "a") {
+                                    try {
+                                        throw TimeoutException("single timeout")
+                                    } catch (_: TimeoutException) {
+                                        MavenArtifact(artifact.groupId, artifact.artifactId, listOf(artifact.version))
+                                    }
+                                } else {
+                                    MavenArtifact(artifact.groupId, artifact.artifactId, listOf("2.0.0", "1.0.0"))
+                                }
+                            }
+                        },
+                        scheduler = scheduler,
+                    )
+
+                val result = CompletableFuture<List<MavenArtifact>>()
+                fetcher.searchArtifacts("example") { result.complete(it) }
+
+                val artifacts = result.get(1, TimeUnit.SECONDS)
+                val artifactAVersions = artifacts.first { it.artifactId == "a" }.versions
+                val artifactBVersions = artifacts.first { it.artifactId == "b" }.versions
+
+                assertThat(artifactAVersions).containsExactly("1.0.0")
+                assertThat(artifactBVersions).containsExactly("2.0.0", "1.0.0")
+            } finally {
+                scheduler.shutdownNow()
+            }
+        }
+
+        @Test
+        fun `returns empty list when search backend never responds`() {
+            val scheduler = Executors.newSingleThreadScheduledExecutor()
+            try {
+                val fetcher =
+                    MavenArtifactFetcher(
+                        project = project,
+                        searchTimeout = 50.milliseconds,
+                        searchBackend = ArtifactSearchBackend { _, _, _ -> },
+                        versionsFetcher = VersionsFetcher { error("should not be called") },
+                        scheduler = scheduler,
+                    )
+
+                val result = CompletableFuture<List<MavenArtifact>>()
+                fetcher.searchArtifacts("detekt") { result.complete(it) }
+
+                assertThat(result.get(1, TimeUnit.SECONDS)).isEmpty()
+            } finally {
+                scheduler.shutdownNow()
+            }
+        }
+
+        @Test
+        fun `falls back to latest version when version fetch fails`() {
+            val scheduler = Executors.newSingleThreadScheduledExecutor()
+            try {
+                val artifact = createArtifact("io.detekt", "detekt-formatting", "1.0.0")
+                val fetcher =
+                    MavenArtifactFetcher(
+                        project = project,
+                        searchTimeout = 50.milliseconds,
+                        searchBackend = ArtifactSearchBackend { _, _, onResults -> onResults(listOf(artifact)) },
+                        versionsFetcher = VersionsFetcher { throw TimeoutException("backend timeout") },
+                        scheduler = scheduler,
+                    )
+
+                val result = CompletableFuture<List<MavenArtifact>>()
+                fetcher.searchArtifacts("detekt-formatting") { result.complete(it) }
+
+                val artifacts = result.get(1, TimeUnit.SECONDS)
+                assertThat(artifacts).hasSize(1)
+                assertThat(artifacts[0].versions).containsExactly("1.0.0")
+            } finally {
+                scheduler.shutdownNow()
+            }
+        }
+    }
+
+    private fun createArtifact(groupId: String, artifactId: String, version: String): RepositoryArtifactDescription =
+        RepositoryArtifactDescription(groupId, artifactId, version, "jar", null)
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/CoordToRelativePathTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/CoordToRelativePathTest.kt
@@ -1,0 +1,19 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CoordToRelativePathTest {
+
+    @Test
+    fun `generates correct relative path from coordinate`() {
+        val path = coordToRelativePath("com.example:my-plugin:1.2.3", "my-plugin-1.2.3.jar")
+        assertThat(path).isEqualTo("com/example/my-plugin/1.2.3/my-plugin-1.2.3.jar")
+    }
+
+    @Test
+    fun `coordToRelativePath handles invalid coordinate with less than 3 parts`() {
+        val path = coordToRelativePath("invalid:coord", "some.jar")
+        assertThat(path).isEqualTo("unknown/some.jar")
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/ExtractCoordinateTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/ExtractCoordinateTest.kt
@@ -1,0 +1,46 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.testFramework.LightVirtualFile
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.idea.maven.utils.library.RepositoryLibraryProperties
+import org.junit.jupiter.api.Test
+
+class ExtractCoordinateTest {
+
+    @Test
+    fun `extracts coordinate from main artifact`() {
+        val props = RepositoryLibraryProperties("com.example", "my-plugin", "1.2.3")
+        val vf = LightVirtualFile("my-plugin-1.2.3.jar")
+
+        val result = extractCoordinate(vf, props, isMain = true)
+
+        assertThat(result).isEqualTo("com.example:my-plugin:1.2.3")
+    }
+
+    @Test
+    fun `extracts coordinate from transitive artifact path`() {
+        val props = RepositoryLibraryProperties("main", "main", "1")
+        // Mock a path that looks like a maven repo path
+        val vf =
+            object : LightVirtualFile("transitive-2.0.0.jar") {
+                override fun getPath() = "/home/user/.m2/repository/org/some/lib/transitive/2.0.0/transitive-2.0.0.jar"
+            }
+
+        val result = extractCoordinate(vf, props, isMain = false)
+
+        assertThat(result).isEqualTo("org.some.lib:transitive:2.0.0")
+    }
+
+    @Test
+    fun `extractCoordinate returns fallback for path without repository marker`() {
+        val props = RepositoryLibraryProperties("main", "main", "1")
+        val vf =
+            object : LightVirtualFile("artifact.jar") {
+                override fun getPath() = "/some/random/path/artifact.jar"
+            }
+
+        val result = extractCoordinate(vf, props, isMain = false)
+
+        assertThat(result).isEqualTo("unknown:artifact:unknown")
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolverTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/MavenDependencyResolverTest.kt
@@ -1,0 +1,388 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.project.Project
+import io.gitlab.arturbosch.detekt.idea.MockProjectTestCase
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.jetbrains.idea.maven.aether.ArtifactDependencyNode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class MavenDependencyResolverTest : MockProjectTestCase() {
+
+    @Test
+    fun `resolve creates node with parsing logic`() {
+        val mockArtifact =
+            object : Artifact by DefaultArtifact("group:artifact:1.0.0") {
+                override fun getFile(): File = File("artifact-1.0.0.jar")
+            }
+        val mockNode = ArtifactDependencyNode(mockArtifact, emptyList<ArtifactDependencyNode>(), false)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = mockNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("group:artifact:1.0.0")
+
+        assertNotNull(node)
+        assertEquals("group", node?.groupId)
+        assertEquals("artifact", node?.artifactId)
+        assertEquals("1.0.0", node?.version)
+        assertEquals("group:artifact:1.0.0", node?.coordinate)
+        assertEquals(false, node?.isProvided)
+        assertEquals(false, node?.isRejected)
+        assertEquals("artifact-1.0.0.jar", node?.file?.name)
+    }
+
+    @Test
+    fun `resolve handles transitive dependencies`() {
+        val childArtifact =
+            object : Artifact by DefaultArtifact("group:child:1.0.0") {
+                override fun getFile(): File = File("child-1.0.0.jar")
+            }
+        val childNode = ArtifactDependencyNode(childArtifact, emptyList<ArtifactDependencyNode>(), false)
+
+        val parentArtifact =
+            object : Artifact by DefaultArtifact("group:parent:1.0.0") {
+                override fun getFile(): File = File("parent-1.0.0.jar")
+            }
+        val parentNode = ArtifactDependencyNode(parentArtifact, listOf(childNode), false)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = parentNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("group:parent:1.0.0")
+
+        assertNotNull(node)
+        assertEquals("group:parent:1.0.0", node?.coordinate)
+        assertEquals(1, node?.children?.size)
+        assertEquals("group:child:1.0.0", node?.children?.get(0)?.coordinate)
+    }
+
+    @Test
+    fun `resolve handles excluded dependencies`() {
+        val excludedArtifact =
+            object : Artifact by DefaultArtifact("org.jetbrains.kotlin:kotlin-stdlib:1.9.0") {
+                override fun getFile(): File = File("irrelevant.jar")
+            }
+        val excludedNode = ArtifactDependencyNode(excludedArtifact, emptyList<ArtifactDependencyNode>(), false)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = excludedNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+
+        assertNotNull(node)
+        assertEquals(true, node?.isProvided)
+    }
+
+    @Test
+    fun `resolve handles rejected dependencies`() {
+        val rejectedArtifact =
+            object : Artifact by DefaultArtifact("group:rejected:1.0.0") {
+                override fun getFile(): File = File("rejected-1.0.0.jar")
+            }
+        val rejectedNode = ArtifactDependencyNode(rejectedArtifact, emptyList<ArtifactDependencyNode>(), true)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = rejectedNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("group:rejected:1.0.0")
+
+        assertNotNull(node)
+        assertEquals(true, node?.isRejected)
+    }
+
+    @Test
+    fun `resolve handles detekt force exclusions`() {
+        val detektArtifact =
+            object : Artifact by DefaultArtifact("io.gitlab.arturbosch.detekt:detekt-api:1.23.0") {
+                override fun getFile(): File = File("irrelevant.jar")
+            }
+        val detektNode = ArtifactDependencyNode(detektArtifact, emptyList(), false)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = detektNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("io.gitlab.arturbosch.detekt:detekt-api:1.23.0")
+
+        assertNotNull(node)
+        assertEquals(true, node?.isProvided)
+    }
+
+    @Test
+    fun `resolve returns null for invalid coordinate`() {
+        val resolver = MavenDependencyResolver(project)
+        val node = resolver.resolve("invalid-coordinate")
+        assertNull(node)
+    }
+
+    @Test
+    fun `resolve returns null when groupId is blank`() {
+        val resolver = MavenDependencyResolver(project)
+        assertNull(resolver.resolve(":artifact:1.0.0"))
+    }
+
+    @Test
+    fun `resolve returns null when artifactId is blank`() {
+        val resolver = MavenDependencyResolver(project)
+        assertNull(resolver.resolve("group::1.0.0"))
+    }
+
+    @Test
+    fun `resolve returns null when version is blank`() {
+        val resolver = MavenDependencyResolver(project)
+        assertNull(resolver.resolve("group:artifact:"))
+    }
+
+    @Test
+    fun `resolve returns null when groupId and artifactId are blank`() {
+        val resolver = MavenDependencyResolver(project)
+        assertNull(resolver.resolve("::1.0.0"))
+    }
+
+    @Test
+    fun `resolve returns null when any GAV part is whitespace only`() {
+        val resolver = MavenDependencyResolver(project)
+        assertNull(resolver.resolve("   :artifact:1.0.0"))
+        assertNull(resolver.resolve("group:   :1.0.0"))
+        assertNull(resolver.resolve("group:artifact:   "))
+    }
+
+    @Test
+    fun `resolve returns null when tree resolver returns null`() {
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = null to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("group:artifact:1.0.0")
+        assertEquals(null, node)
+    }
+
+    @Test
+    fun `resolve uses artifact file when resolved files map is empty`() {
+        val mockArtifact =
+            object : Artifact by DefaultArtifact("group:artifact:1.0.0") {
+                override fun getFile(): File = File("artifact-1.0.0.jar")
+            }
+        val mockNode = ArtifactDependencyNode(mockArtifact, emptyList<ArtifactDependencyNode>(), false)
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = mockNode to emptyMap()
+            },
+        )
+
+        val node = resolver.resolve("group:artifact:1.0.0")
+
+        assertNotNull(node)
+        // Should use the artifact's file directly when not in resolved files map
+        assertEquals("artifact-1.0.0.jar", node?.file?.name)
+    }
+
+    @Test
+    fun `resolve prefers resolved files map over artifact file`() {
+        val mockArtifact =
+            object : Artifact by DefaultArtifact("group:artifact:1.0.0") {
+                override fun getFile(): File? = null // No file on artifact
+            }
+        val mockNode = ArtifactDependencyNode(mockArtifact, emptyList<ArtifactDependencyNode>(), false)
+        val resolvedFiles = mapOf("group:artifact:1.0.0" to File("resolved-artifact.jar"))
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> = mockNode to resolvedFiles
+            },
+        )
+
+        val node = resolver.resolve("group:artifact:1.0.0")
+
+        assertNotNull(node)
+        assertEquals("resolved-artifact.jar", node?.file?.name)
+    }
+
+    @Test
+    fun `flattening and uniqueness logic works correctly`() {
+        val sharedDep =
+            MavenDependencyResolver.ResolvedNode(
+                "group",
+                "shared",
+                "1.0.0",
+                "group:shared:1.0.0",
+                isProvided = false,
+                isRejected = false,
+                children = emptyList(),
+            )
+        val child1 =
+            MavenDependencyResolver.ResolvedNode(
+                "group",
+                "child1",
+                "1.0.0",
+                "group:child1:1.0.0",
+                isProvided = false,
+                isRejected = false,
+                children = listOf(sharedDep),
+            )
+        val child2 =
+            MavenDependencyResolver.ResolvedNode(
+                "group",
+                "child2",
+                "1.0.0",
+                "group:child2:1.0.0",
+                isProvided = false,
+                isRejected = false,
+                children = listOf(sharedDep),
+            )
+        val root =
+            MavenDependencyResolver.ResolvedNode(
+                "group",
+                "root",
+                "1.0.0",
+                "group:root:1.0.0",
+                isProvided = false,
+                isRejected = false,
+                children = listOf(child1, child2),
+            )
+
+        val resolver = MavenDependencyResolver(project)
+        val flattened = resolver.flatten(root)
+
+        // Total nodes in tree (root + child1 + shared + child2 + shared) = 5
+        assertEquals(5, flattened.size)
+
+        // Distinct coordinates (root, child1, child2, shared) = 4
+        val distinctCount = flattened.distinctBy { it.coordinate }.size
+        assertEquals(4, distinctCount)
+
+        // Transitive dependencies (excluding root)
+        val transitiveDistinctCount =
+            flattened.filter { it.coordinate != root.coordinate }.distinctBy { it.coordinate }.size
+        assertEquals(3, transitiveDistinctCount)
+    }
+
+    @Test
+    fun `resolve passes indicator to tree resolver`() {
+        var passedIndicator: ProgressIndicator? = null
+        val mockIndicator =
+            java.lang.reflect.Proxy.newProxyInstance(
+                ProgressIndicator::class.java.classLoader,
+                arrayOf(ProgressIndicator::class.java),
+            ) { _, _, _ ->
+                null
+            } as ProgressIndicator
+
+        val resolver = MavenDependencyResolver(
+            project,
+            object : MavenTreeResolver {
+                override fun resolveDependenciesTree(
+                    groupId: String,
+                    artifactId: String,
+                    version: String,
+                    project: Project,
+                    shouldDownload: Boolean,
+                    exclusions: List<String>,
+                    indicator: ProgressIndicator?,
+                ): Pair<ArtifactDependencyNode?, Map<String, File>> {
+                    passedIndicator = indicator
+                    return null to emptyMap()
+                }
+            },
+        )
+
+        resolver.resolve("group:artifact:1.0.0", indicator = mockIndicator)
+        assertTrue(mockIndicator === passedIndicator)
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginDependencyServiceTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/PluginDependencyServiceTest.kt
@@ -1,0 +1,292 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import io.gitlab.arturbosch.detekt.idea.MockProjectTestCase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PluginDependencyServiceTest : MockProjectTestCase() {
+
+    @Test
+    fun `returns correct plugin folder`() {
+        val service = PluginDependencyService(project)
+        val folder = service.getPluginFolder()
+        assertThat(folder.toString()).isEqualTo(tempDir.resolve(".idea/detektPlugins").toString())
+    }
+
+    @Test
+    fun `collectAllowedNodes filters out provided dependencies`() {
+        val service = PluginDependencyService(project)
+        val providedNode = MavenDependencyResolver.ResolvedNode(
+            "org.jetbrains.kotlin",
+            "kotlin-stdlib",
+            "1.9.0",
+            "org.jetbrains.kotlin:kotlin-stdlib:1.9.0",
+            isProvided = true,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val normalNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "lib",
+            "1.0.0",
+            "com.example:lib:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val rootNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "plugin",
+            "1.0.0",
+            "com.example:plugin:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(providedNode, normalNode),
+        )
+
+        val result = service.collectAllowedNodes(rootNode, emptySet())
+
+        assertThat(result.map { it.coordinate })
+            .containsExactlyInAnyOrder("com.example:plugin:1.0.0", "com.example:lib:1.0.0")
+            .doesNotContain("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+    }
+
+    @Test
+    fun `collectAllowedNodes respects explicit exclusions`() {
+        val service = PluginDependencyService(project)
+        val excludedNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "excluded",
+            "1.0.0",
+            "com.example:excluded:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val rootNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "plugin",
+            "1.0.0",
+            "com.example:plugin:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(excludedNode),
+        )
+
+        val result = service.collectAllowedNodes(rootNode, setOf("com.example:excluded"))
+
+        assertThat(result.map { it.coordinate })
+            .containsExactly("com.example:plugin:1.0.0")
+            .doesNotContain("com.example:excluded:1.0.0")
+    }
+
+    @Test
+    fun `collectAllowedNodes handles relative exclusions`() {
+        val service = PluginDependencyService(project)
+        val childNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "child",
+            "1.0.0",
+            "com.example:child:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val parentNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "parent",
+            "1.0.0",
+            "com.example:parent:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(childNode),
+        )
+
+        // When parent is excluded, children should also be excluded because they are
+        // reached
+        // through parent
+        val result = service.collectAllowedNodes(parentNode, setOf("com.example:parent"))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `collectAllowedNodes handles deeply nested trees`() {
+        val service = PluginDependencyService(project)
+        val level3 = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "level3",
+            "1.0.0",
+            "com.example:level3:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val level2 = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "level2",
+            "1.0.0",
+            "com.example:level2:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(level3),
+        )
+        val level1 = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "level1",
+            "1.0.0",
+            "com.example:level1:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(level2),
+        )
+        val root = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "root",
+            "1.0.0",
+            "com.example:root:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(level1),
+        )
+
+        val result = service.collectAllowedNodes(root, emptySet())
+
+        assertThat(result.map { it.coordinate })
+            .containsExactlyInAnyOrder(
+                "com.example:root:1.0.0",
+                "com.example:level1:1.0.0",
+                "com.example:level2:1.0.0",
+                "com.example:level3:1.0.0",
+            )
+    }
+
+    @Test
+    fun `collectAllowedNodes handles node with empty children`() {
+        val service = PluginDependencyService(project)
+        val rootNode = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "plugin",
+            "1.0.0",
+            "com.example:plugin:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+
+        val result = service.collectAllowedNodes(rootNode, emptySet())
+
+        assertThat(result.map { it.coordinate }).containsExactly("com.example:plugin:1.0.0")
+    }
+
+    @Test
+    fun `collectAllowedNodes deduplicates nodes with same coordinate`() {
+        val service = PluginDependencyService(project)
+        // Same dependency appearing twice in tree (diamond dependency)
+        val sharedDep = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "shared",
+            "1.0.0",
+            "com.example:shared:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(),
+        )
+        val child1 = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "child1",
+            "1.0.0",
+            "com.example:child1:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(sharedDep),
+        )
+        val child2 = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "child2",
+            "1.0.0",
+            "com.example:child2:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(sharedDep),
+        )
+        val root = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "root",
+            "1.0.0",
+            "com.example:root:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(child1, child2),
+        )
+
+        val result = service.collectAllowedNodes(root, emptySet())
+
+        // shared should only appear once despite being in both child1 and child2
+        assertThat(result.count { it.coordinate == "com.example:shared:1.0.0" }).isEqualTo(1)
+        assertThat(result.map { it.coordinate })
+            .containsExactlyInAnyOrder(
+                "com.example:root:1.0.0",
+                "com.example:child1:1.0.0",
+                "com.example:child2:1.0.0",
+                "com.example:shared:1.0.0",
+            )
+    }
+
+    @Test
+    fun `collectAllowedNodes handles direct cycles`() {
+        val service = PluginDependencyService(project)
+        // Need to use a lazy-initialized list or a mutable list to create a cycle in
+        // ResolvedNode
+        // which is a data class with an immutable list of children.
+        // However, we can use a custom subclass if needed, or just mock it.
+        // Let's create a cycle by passing the same node as a child.
+        val root = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "root",
+            "1.0.0",
+            "com.example:root:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(), // will be swapped
+        )
+
+        val cyclicNode = root.copy(children = listOf(root))
+
+        val result = service.collectAllowedNodes(cyclicNode, emptySet())
+
+        assertThat(result.map { it.coordinate }).containsExactly("com.example:root:1.0.0")
+    }
+
+    @Test
+    fun `collectAllowedNodes handles indirect cycles`() {
+        val service = PluginDependencyService(project)
+        val nodeB = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "nodeB",
+            "1.0.0",
+            "com.example:nodeB:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = emptyList(), // cycle back to A
+        )
+        val nodeA = MavenDependencyResolver.ResolvedNode(
+            "com.example",
+            "nodeA",
+            "1.0.0",
+            "com.example:nodeA:1.0.0",
+            isProvided = false,
+            isRejected = false,
+            children = listOf(nodeB),
+        )
+
+        // Close the cycle: B -> A
+        val nodeBWithCycle = nodeB.copy(children = listOf(nodeA))
+        val nodeAWithCycle = nodeA.copy(children = listOf(nodeBWithCycle))
+
+        val result = service.collectAllowedNodes(nodeAWithCycle, emptySet())
+
+        assertThat(result.map { it.coordinate })
+            .containsExactlyInAnyOrder("com.example:nodeA:1.0.0", "com.example:nodeB:1.0.0")
+    }
+}

--- a/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProvidedDependenciesTest.kt
+++ b/src/test/kotlin/io/gitlab/arturbosch/detekt/idea/util/ProvidedDependenciesTest.kt
@@ -1,0 +1,53 @@
+package io.gitlab.arturbosch.detekt.idea.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProvidedDependenciesTest {
+
+    @Test
+    fun `should exclude detekt dependencies`() {
+        assertThat(ProvidedDependencies.isProvided("io.gitlab.arturbosch.detekt", "detekt-api")).isTrue()
+        assertThat(ProvidedDependencies.isProvided("io.gitlab.arturbosch.detekt", "detekt-core")).isTrue()
+    }
+
+    @Test
+    fun `should exclude kotlin dependencies`() {
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlin", "kotlin-stdlib")).isTrue()
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlin", "kotlin-reflect")).isTrue()
+    }
+
+    @Test
+    fun `should handle kotlinx dependencies granularly`() {
+        // Excluded
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlinx", "kotlinx-coroutines-core")).isTrue()
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8")).isTrue()
+
+        // Not excluded
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlinx", "kotlinx-serialization-json")).isFalse()
+        assertThat(ProvidedDependencies.isProvided("org.jetbrains.kotlinx", "kotlinx-html-jvm")).isFalse()
+    }
+
+    @Test
+    fun `should not exclude other dependencies`() {
+        assertThat(ProvidedDependencies.isProvided("com.example", "my-lib")).isFalse()
+        assertThat(ProvidedDependencies.isProvided("org.junit.jupiter", "junit-jupiter-api")).isFalse()
+    }
+
+    @Test
+    fun `should exclude dev detekt dependencies`() {
+        assertThat(ProvidedDependencies.isProvided("dev.detekt", "detekt-api")).isTrue()
+        assertThat(ProvidedDependencies.isProvided("dev.detekt", "detekt-core")).isTrue()
+        assertThat(ProvidedDependencies.isProvided("dev.detekt", "detekt-psi-utils")).isTrue()
+    }
+
+    @Test
+    fun `getExclusions returns all provided group patterns`() {
+        val exclusions = ProvidedDependencies.getExclusions()
+
+        assertThat(exclusions).contains("io.gitlab.arturbosch.detekt:*")
+        assertThat(exclusions).contains("dev.detekt:*")
+        assertThat(exclusions).contains("org.jetbrains.kotlin:*")
+        assertThat(exclusions).contains("org.jetbrains.kotlinx:kotlinx-coroutines-*")
+    }
+}


### PR DESCRIPTION
## Overview
This PR introduces a sophisticated system for managing **detekt plugins** directly from the IDE. Users can now extend detekt with third-party rule sets (such as those found on the [detekt marketplace](https://detekt.dev/marketplace)) via Maven repositories, complete with automatic transitive dependency resolution and a local lifecycle management system.

Demo:

https://github.com/user-attachments/assets/ddb74216-e7da-4704-b1a8-920495f587b2

Downloaded plugin JARs:
<img width="319" height="242" alt="image" src="https://github.com/user-attachments/assets/6930faf6-546a-4808-80fe-56e958bcd57b" />

## Key Advantages
- **No More Manual Hunting**: users no longer need to go hunting on GitHub releases or random websites to manually find and download the correct "fat" JARs for plugins. Everything is searchable and resolvable directly within the IDE.
- **Improved Provenance**: by resolving artefacts directly from Maven repositories, we eliminate the need to commit binary JARs to the project’s VCS. This simplifies security audits, ensures transparency of library origins, and keeps the repository history lean. It also avoids plonking large fat JAR binary blobs under VCS, which is never ideal.
- **Conflict Prevention**: the system automatically identifies and excludes "provided" dependencies (like detekt-api or kotlin-stdlib) from the resolution to ensure plugin JARs don’t cause collisions with the plugin runtime classpath.

## Architectural Highlights
*   **Plugin Infrastructure**: introduced `PluginDependencyService` to orchestrate the lifecycle of plugin JARs. Plugins are now stored in a project-local folder (`.idea/detektPlugins/`) and tracked via a state file, `downloaded.json`.
*   **Maven Integration**: leveraging IntelliJ’s internal Maven infrastructure (via `JarRepositoryManager` and `ArtifactRepositoryManager`), we can reliably discover and resolve detekt plugin artefacts through the new `MavenDependencyResolver` and `MavenArtifactFetcher`.
*   **Automatic Reconciliation**: implemented a synchronisation mechanism that ensures the local plugin folder state matches the current project configuration. This runs as a background task on settings application, project opening, or VCS-triggered state reloads (ensuring team-wide consistency). It cleans up unused JARs and downloads new ones.
*   **Dependency Exclusion UI**: added an interactive `DependencyExclusionEditor` for selective exclusion of transitive dependencies. It is a fork of IntelliJ’s own private UI for JPS, but with extra rules and code to support our specific needs.

Further details are available in the `DETEKT_PLUGINS.md` file, which is provided for guidance and future reference.

## Main parts
| Component | Responsibility |
| --- | --- |
| **`PluginDependencyService`** | Project service handling JAR lifecycle, reconciliation, and clean-up. |
| **`MavenSearchDialog`** | New UI for free-text or GAV-based search, version selection, and dependency preview. |
| **`DependencyExclusionEditor`** | Tree-based interface for management; forked and adapted from JPS’ internal UI. |
| **`DETEKT_PLUGINS.md`** | Comprehensive technical documentation covering data flow and architecture. |

## Platform Updates
*   **Base Version Bump**: updated IntelliJ Platform `sinceBuild` to **242** (2024.2).
*   **Toolchain**: Updated JVM toolchain to **21** to align with the new base platform requirements.
*   **Dependencies**: Added `org.jetbrains.idea.maven` as a required plugin dependency to expose underlying Maven machinery.

## Future Improvements
1.  **Update Notifications**: implement notifications when a newer version of an installed plugin is available on Maven.
2.  **Smart Migration**: automated migration path for users currently using local plugin JARs to move them to Maven-based management.
3.  **Marketplace Integration**: pull featured plugins from the marketplace and show them as suggestions in the search field. (Requires the website to host a JSON, or provide an API)
4. **VCS ignore suggestion**: if the plugin detects VCS does not ignore the  folder, it recommends adding it to the ignored list.

> [!NOTE]
> While I have performed extensive manual testing and the PR includes a comprehensive suite of automated tests (covering GAV parsing, cycle detection, and resolution), **please perform a thorough manual review and test cycle**. 
> 
> Maven infrastructure can be unpredictable across different environments/caches, and transitive dependency "fun" can manifest in unexpected ways.

---

> [!IMPORTANT]
> **AI Disclosure:** this change was co-developed using LLM-based agents (primarily Gemini 3 models, and a tiny bit of Claude 4.5 too). That said, all changes in this PR have then been manually reviewed, tweaked, and refactored by yours truly to minimise changes and ensure consistency.